### PR TITLE
feat: move utils and client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,9 @@ const resolvePath = (p: string) => (path.isAbsolute(p) ? p : path.resolve(cwd, p
 
 const serializeDecode = (serializer: TSerializer) => async (
 	decoded: Right<ValidationError[], TSwaggerObject>,
+	apiOut: string,
 	out: string,
-): Promise<TFSEntity> => serializer(path.basename(out), decoded.value);
+): Promise<TFSEntity> => serializer(path.basename(apiOut), decoded.value, out);
 
 const getPrettierConfig = async (pathToPrettierConfig?: string): Promise<Option<prettier.Options>> =>
 	fromNullable(
@@ -88,7 +89,7 @@ export const generate = async (options: TGenerateOptions): Promise<void> => {
 			ThrowReporter.report(decoded);
 			return;
 		}
-		const seralized = await serializer(decoded, apiOut);
+		const seralized = await serializer(decoded, apiOut, out);
 		const formatted = formatSerialized(seralized, prettierConfig);
 		writeFormatted(apiOut, formatted);
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ import { camelize } from '@devexperts/utils/dist/string/string';
 import { option, Option, some } from 'fp-ts/lib/Option';
 import { sequence } from 'fp-ts/lib/Traversable';
 
-export type TSerializer = (name: string, schema: TSwaggerObject) => TFSEntity;
+export type TSerializer = (name: string, schema: TSwaggerObject, out: string) => TFSEntity;
 
 export const getOperationsFromPath = (path: TPathItemObject): TDictionary<TOperationObject> => {
 	const result: TDictionary<TOperationObject> = {};


### PR DESCRIPTION
utils and client was generated 1 instance for each spec. now there's only one instance for all at the same level as specs