### PR TITLE
refactor: propagate errors

### DIFF
--- a/src/language/typescript/2.0-rx/index.ts
+++ b/src/language/typescript/2.0-rx/index.ts
@@ -2,19 +2,24 @@ import { SwaggerObject } from '../../../schema/2.0/swagger-object';
 import { defaultPrettierConfig, SerializeOptions } from '../common/utils';
 import { directory, FSEntity, map } from '../../../utils/fs';
 import { Dictionary } from '../../../utils/types';
-import { record } from 'fp-ts';
+import { either, record } from 'fp-ts';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { serializeSwaggerObject } from './serializers/swagger-object';
 import { format } from 'prettier';
+import { Either } from 'fp-ts/lib/Either';
+import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
 
 export const serialize = (
 	out: string,
 	documents: Dictionary<SwaggerObject>,
 	options: SerializeOptions = {},
-): FSEntity => {
-	const serialized = pipe(
+): Either<Error, FSEntity> =>
+	pipe(
 		documents,
 		record.collect(serializeSwaggerObject),
+		sequenceEither,
+		either.map(serialized => directory(out, serialized)),
+		either.map(serialized =>
+			map(serialized, content => format(content, options.prettierConfig || defaultPrettierConfig)),
+		),
 	);
-	return map(directory(out, serialized), content => format(content, options.prettierConfig || defaultPrettierConfig));
-};

--- a/src/language/typescript/2.0-rx/serializers/definitions-object.ts
+++ b/src/language/typescript/2.0-rx/serializers/definitions-object.ts
@@ -3,28 +3,35 @@ import { directory, Directory, file, File } from '../../../../utils/fs';
 import { serializeSchemaObject } from './schema-object';
 import { serializeDependencies } from '../../common/data/serialized-dependency';
 import { DefinitionsObject } from '../../../../schema/2.0/definitions-object';
-import { serializeDictionary } from '../../../../utils/types';
 import { DEFINITIONS_DIRECTORY, getIOName, ROOT_DIRECTORY } from '../../common/utils';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { either, record } from 'fp-ts';
+import { Either } from 'fp-ts/lib/Either';
+import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
 
-export const serializeDefinitions = (definitions: DefinitionsObject): Directory =>
-	directory(DEFINITIONS_DIRECTORY, [
-		...serializeDictionary(definitions, (name, definition) =>
+export const serializeDefinitions = (definitions: DefinitionsObject): Either<Error, Directory> =>
+	pipe(
+		definitions,
+		record.collect((name, definition) =>
 			serializeDefinition(name, definition, `${ROOT_DIRECTORY}/${DEFINITIONS_DIRECTORY}`),
 		),
-	]);
-
-const serializeDefinition = (name: string, definition: SchemaObject, cwd: string): File => {
-	const serialized = serializeSchemaObject(definition, name, cwd);
-
-	const dependencies = serializeDependencies(serialized.dependencies);
-
-	return file(
-		`${name}.ts`,
-		`
-			${dependencies}
-			
-			export type ${name} = ${serialized.type};
-			export const ${getIOName(name)} = ${serialized.io};
-		`,
+		sequenceEither,
+		either.map(serialized => directory(DEFINITIONS_DIRECTORY, serialized)),
 	);
-};
+
+const serializeDefinition = (name: string, definition: SchemaObject, cwd: string): Either<Error, File> =>
+	pipe(
+		serializeSchemaObject(definition, name, cwd),
+		either.map(serialized => {
+			const dependencies = serializeDependencies(serialized.dependencies);
+			return file(
+				`${name}.ts`,
+				`
+					${dependencies}
+					
+					export type ${name} = ${serialized.type};
+					export const ${getIOName(name)} = ${serialized.io};
+				`,
+			);
+		}),
+	);

--- a/src/language/typescript/2.0-rx/serializers/paths-object.ts
+++ b/src/language/typescript/2.0-rx/serializers/paths-object.ts
@@ -2,15 +2,21 @@ import { PathsObject } from '../../../../schema/2.0/paths-object';
 import { Option } from 'fp-ts/lib/Option';
 import { ParametersDefinitionsObject } from '../../../../schema/2.0/parameters-definitions-object';
 import { directory, Directory } from '../../../../utils/fs';
-import { serializeDictionary } from '../../../../utils/types';
 import { groupPathsByTag } from '../../../../utils/utils';
 import { serializePathGroup } from './path-item-object';
 import { CONTROLLERS_DIRECTORY, ROOT_DIRECTORY } from '../../common/utils';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { either, record } from 'fp-ts';
+import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
+import { Either } from 'fp-ts/lib/Either';
 
-export const serializePaths = (paths: PathsObject, parameters: Option<ParametersDefinitionsObject>): Directory =>
-	directory(
-		CONTROLLERS_DIRECTORY,
-		serializeDictionary(groupPathsByTag(paths, parameters), (name, group) =>
-			serializePathGroup(name, group, `${ROOT_DIRECTORY}/${CONTROLLERS_DIRECTORY}`),
-		),
+export const serializePaths = (
+	paths: PathsObject,
+	parameters: Option<ParametersDefinitionsObject>,
+): Either<Error, Directory> =>
+	pipe(
+		groupPathsByTag(paths, parameters),
+		record.collect((name, group) => serializePathGroup(name, group, `${ROOT_DIRECTORY}/${CONTROLLERS_DIRECTORY}`)),
+		sequenceEither,
+		either.map(serialized => directory(CONTROLLERS_DIRECTORY, serialized)),
 	);

--- a/src/language/typescript/2.0-rx/serializers/response-object.ts
+++ b/src/language/typescript/2.0-rx/serializers/response-object.ts
@@ -3,13 +3,14 @@ import { map, Option } from 'fp-ts/lib/Option';
 import { SerializedType } from '../../common/data/serialized-type';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { serializeSchemaObject } from './schema-object';
+import { Either } from 'fp-ts/lib/Either';
 
 export const serializeOperationResponse = (
 	code: string,
 	response: ResponseObject,
 	rootName: string,
 	cwd: string,
-): Option<SerializedType> =>
+): Option<Either<Error, SerializedType>> =>
 	pipe(
 		response.schema,
 		map(schema => serializeSchemaObject(schema, rootName, cwd)),

--- a/src/language/typescript/2.0-rx/serializers/schema-object.ts
+++ b/src/language/typescript/2.0-rx/serializers/schema-object.ts
@@ -1,9 +1,14 @@
-import { foldSerializedTypes, serializedType, SerializedType } from '../../common/data/serialized-type';
 import {
-	serializedDependency,
+	foldSerializedTypes,
+	SERIALIZED_UNKNOWN_TYPE,
+	serializedType,
+	SerializedType,
+} from '../../common/data/serialized-type';
+import {
 	EMPTY_DEPENDENCIES,
 	monoidDependencies,
 	OPTION_DEPENDENCIES,
+	serializedDependency,
 } from '../../common/data/serialized-dependency';
 import { getRelativeOutRefPath, getRelativeRefPath } from '../utils';
 import { SchemaObject } from '../../../../schema/2.0/schema-object/schema-object';
@@ -23,18 +28,24 @@ import {
 import { pipe } from 'fp-ts/lib/pipeable';
 import { fold, monoidString } from 'fp-ts/lib/Monoid';
 import { intercalate } from 'fp-ts/lib/Foldable';
-import { array, getMonoid } from 'fp-ts/lib/Array';
-import { serializeDictionary } from '../../../../utils/types';
+import { getMonoid } from 'fp-ts/lib/Array';
 import { constFalse } from 'fp-ts/lib/function';
 import { concatIf, concatIfL } from '../../../../utils/array';
 import { ReferenceSchemaObject } from '../../../../schema/2.0/schema-object/reference-schema-object';
 import { AllOfSchemaObject } from '../../../../schema/2.0/schema-object/all-of-schema-object';
 import { camelize } from '@devexperts/utils/dist/string';
-import { getIOName, getRelativeUtilsPath } from '../../common/utils';
-import { Ref, fromString } from '../../../../utils/ref';
-import { isLeft } from 'fp-ts/lib/Either';
+import { getIOName } from '../../common/utils';
+import { fromString, Ref } from '../../../../utils/ref';
+import { Either, isLeft, left, right } from 'fp-ts/lib/Either';
+import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
+import { array, either, option, record } from 'fp-ts';
+import { traverseArrayEither } from '../../../../utils/either';
 
-export const serializeSchemaObject = (schema: SchemaObject, rootName: string, cwd: string): SerializedType => {
+export const serializeSchemaObject = (
+	schema: SchemaObject,
+	rootName: string,
+	cwd: string,
+): Either<Error, SerializedType> => {
 	switch (schema.type) {
 		case undefined: {
 			if (is$ref(schema)) {
@@ -57,7 +68,7 @@ export const serializeSchemaObject = (schema: SchemaObject, rootName: string, cw
 				);
 
 				if (isNone(safeType) || isNone(defBlock) || isLeft(parsedRef)) {
-					throw new Error(`Invalid $ref: ${$ref}`);
+					return left(new Error(`Invalid $ref: ${$ref}`));
 				}
 
 				const type = safeType.value;
@@ -84,30 +95,36 @@ export const serializeSchemaObject = (schema: SchemaObject, rootName: string, cw
 					),
 				);
 
-				return serializedType(
-					defName(type),
-					defName(io),
-					isRecursive
-						? EMPTY_DEPENDENCIES
-						: [
-								serializedDependency(asDefName(type), definitionFilePath),
-								serializedDependency(asDefName(io), definitionFilePath),
-						  ],
-					[parsedRef.right],
+				return right(
+					serializedType(
+						defName(type),
+						defName(io),
+						isRecursive
+							? EMPTY_DEPENDENCIES
+							: [
+									serializedDependency(asDefName(type), definitionFilePath),
+									serializedDependency(asDefName(io), definitionFilePath),
+							  ],
+						[parsedRef.right],
+					),
 				);
 			}
 
-			const results = schema.allOf.map(item => serializeSchemaObject(item, rootName, cwd));
-			const types = results.map(item => item.type);
-			const ios = results.map(item => item.io);
-			const dependencies = fold(monoidDependencies)(results.map(item => item.dependencies));
-			const refs = fold(getMonoid<Ref>())(results.map(item => item.refs));
+			return pipe(
+				traverseArrayEither(schema.allOf, item => serializeSchemaObject(item, rootName, cwd)),
+				either.map(results => {
+					const types = results.map(item => item.type);
+					const ios = results.map(item => item.io);
+					const dependencies = fold(monoidDependencies)(results.map(item => item.dependencies));
+					const refs = fold(getMonoid<Ref>())(results.map(item => item.refs));
 
-			return serializedType(
-				intercalate(monoidString, array)(' & ', types),
-				`intersection([${intercalate(monoidString, array)(', ', ios)}])`,
-				[serializedDependency('intersection', 'io-ts'), ...dependencies],
-				refs,
+					return serializedType(
+						intercalate(monoidString, array.array)(' & ', types),
+						`intersection([${intercalate(monoidString, array.array)(', ', ios)}])`,
+						[serializedDependency('intersection', 'io-ts'), ...dependencies],
+						refs,
+					);
+				}),
 			);
 		}
 		case 'string': {
@@ -140,69 +157,80 @@ export const serializeSchemaObject = (schema: SchemaObject, rootName: string, cw
 					),
 				),
 				getOrElse(() => serializedType('string', 'string', [serializedDependency('string', 'io-ts')], [])),
+				right,
 			);
 		}
 		case 'boolean': {
-			return serializedType('boolean', 'boolean', [serializedDependency('boolean', 'io-ts')], []);
+			return right(serializedType('boolean', 'boolean', [serializedDependency('boolean', 'io-ts')], []));
 		}
 		case 'integer':
 		case 'number': {
-			return serializedType('number', 'number', [serializedDependency('number', 'io-ts')], []);
+			return right(serializedType('number', 'number', [serializedDependency('number', 'io-ts')], []));
 		}
 		case 'array': {
-			const result = serializeSchemaObject(schema.items, rootName, cwd);
-			return serializedType(
-				`Array<${result.type}>`,
-				`array(${result.io})`,
-				[...result.dependencies, serializedDependency('array', 'io-ts')],
-				result.refs,
+			return pipe(
+				serializeSchemaObject(schema.items, rootName, cwd),
+				either.map(result =>
+					serializedType(
+						`Array<${result.type}>`,
+						`array(${result.io})`,
+						[...result.dependencies, serializedDependency('array', 'io-ts')],
+						result.refs,
+					),
+				),
 			);
 		}
 		case 'object': {
-			return pipe(
+			const additionalProperties = pipe(
 				schema.additionalProperties,
-				map(additionalProperties => serializeAdditionalProperties(additionalProperties, rootName, cwd)),
-				alt(() =>
-					pipe(
-						schema.properties,
-						map(properties => {
-							const serialized = foldSerializedTypes(
-								serializeDictionary(properties, (name, value) => {
-									const isRequired = pipe(
-										schema.required,
-										map(required => required.includes(name)),
-										getOrElse(constFalse),
-									);
-									const field = serializeSchemaObject(value, rootName, cwd);
-									const type = isRequired
-										? `${name}: ${field.type}`
-										: `${name}: Option<${field.type}>`;
-									const io = isRequired
-										? `${name}: ${field.io}`
-										: `${name}: optionFromNullable(${field.io})`;
-									return serializedType(
-										`${type};`,
-										`${io},`,
-										concatIf(!isRequired, field.dependencies, OPTION_DEPENDENCIES),
-										field.refs,
-									);
-								}),
-							);
-							return toObjectType(
-								serialized,
-								serialized.refs.some(ref => ref.name === rootName) ? some(rootName) : none,
-							);
-						}),
+				option.map(additionalProperties => serializeAdditionalProperties(additionalProperties, rootName, cwd)),
+			);
+			const properties = () =>
+				pipe(
+					schema.properties,
+					option.map(properties =>
+						pipe(
+							properties,
+							record.collect((name, value) => {
+								const isRequired = pipe(
+									schema.required,
+									map(required => required.includes(name)),
+									getOrElse(constFalse),
+								);
+								return pipe(
+									serializeSchemaObject(value, rootName, cwd),
+									either.map(field => {
+										const type = isRequired
+											? `${name}: ${field.type}`
+											: `${name}: Option<${field.type}>`;
+										const io = isRequired
+											? `${name}: ${field.io}`
+											: `${name}: optionFromNullable(${field.io})`;
+										return serializedType(
+											`${type};`,
+											`${io},`,
+											concatIf(!isRequired, field.dependencies, OPTION_DEPENDENCIES),
+											field.refs,
+										);
+									}),
+								);
+							}),
+							sequenceEither,
+							either.map(foldSerializedTypes),
+							either.map(serialized =>
+								toObjectType(
+									serialized,
+									serialized.refs.some(ref => ref.name === rootName) ? some(rootName) : none,
+								),
+							),
+						),
 					),
-				),
-				getOrElse(() =>
-					serializedType(
-						'unknown',
-						'unknownType',
-						[serializedDependency('unknownType', getRelativeUtilsPath(cwd))],
-						[],
-					),
-				),
+				);
+
+			return pipe(
+				additionalProperties,
+				option.alt(properties),
+				getOrElse(() => right(SERIALIZED_UNKNOWN_TYPE)),
 			);
 		}
 	}
@@ -241,19 +269,26 @@ const serializeEnum = (enumValue: Array<string | number | boolean>): SerializedT
 	);
 };
 
-const serializeAdditionalProperties = (properties: SchemaObject, rootName: string, cwd: string): SerializedType => {
-	const additional = serializeSchemaObject(properties, rootName, cwd);
-	return serializedType(
-		`{ [key: string]: ${additional.type} }`,
-		`dictionary(string, ${additional.io})`,
-		[
-			...additional.dependencies,
-			serializedDependency('string', 'io-ts'),
-			serializedDependency('dictionary', 'io-ts'),
-		],
-		additional.refs,
+const serializeAdditionalProperties = (
+	properties: SchemaObject,
+	rootName: string,
+	cwd: string,
+): Either<Error, SerializedType> =>
+	pipe(
+		serializeSchemaObject(properties, rootName, cwd),
+		either.map(additional =>
+			serializedType(
+				`{ [key: string]: ${additional.type} }`,
+				`dictionary(string, ${additional.io})`,
+				[
+					...additional.dependencies,
+					serializedDependency('string', 'io-ts'),
+					serializedDependency('dictionary', 'io-ts'),
+				],
+				additional.refs,
+			),
+		),
 	);
-};
 
 const getDefName = (name: string, prefix: string): string => `${camelize(prefix, true)}${name}`;
 const getDefIFSameName = (isSameOutName: boolean, prefix: string) => (name: string): string =>

--- a/src/language/typescript/common/utils.ts
+++ b/src/language/typescript/common/utils.ts
@@ -15,8 +15,6 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 
 export const getRelativeRoot = (cwd: string) => path.relative(cwd, ROOT_DIRECTORY);
 export const getRelativeClientPath = (cwd: string): string =>
 	`${getRelativeRoot(cwd)}/${CLIENT_DIRECTORY}/${CLIENT_FILENAME}`;
-export const getRelativeUtilsPath = (cwd: string): string =>
-	`${getRelativeRoot(cwd)}/${UTILS_DIRECTORY}/${UTILS_FILENAME}`;
 
 const INVALID_NAMES = ['Error', 'Promise', 'PromiseLike', 'Array', 'ArrayLike', 'Function', 'Object'];
 export const getTypeName = (name: string): string => (INVALID_NAMES.includes(name) ? `${name}Type` : name);

--- a/src/utils/either.ts
+++ b/src/utils/either.ts
@@ -1,0 +1,4 @@
+import { array } from 'fp-ts/lib/Array';
+import { either } from 'fp-ts/lib/Either';
+
+export const traverseArrayEither = array.traverse(either);

--- a/src/utils/ref.ts
+++ b/src/utils/ref.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import { isNonEmpty } from 'fp-ts/lib/Array';
 import { last, NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { Either, left, right } from 'fp-ts/lib/Either';
-import { pipe } from 'fp-ts/lib/pipeable';
-import { either, nonEmptyArray } from 'fp-ts';
 
 export interface Ref {
 	readonly $ref: string;
@@ -72,21 +70,6 @@ export const fromString = ($ref: string): Either<Error, Ref> => {
 		target,
 	});
 };
-
-export const buildRelativePath = (cwd: string, ref: Ref): string => {
-	const toRoot = path.relative(cwd, ref.target === '' ? '.' : '..');
-	const joined = path.join(toRoot, ref.target, ref.path);
-	return joined.startsWith('..') ? joined : `./${joined}`;
-};
-
-export interface Refs extends NonEmptyArray<Ref> {}
-
-export const fromStrings = (...paths: NonEmptyArray<string>): Either<Error, Refs> =>
-	pipe(
-		paths,
-		nonEmptyArray.map(fromString),
-		nonEmptyArray.nonEmptyArray.sequence(either.either),
-	);
 
 export const addPathParts = (...parts: NonEmptyArray<string>) => (ref: Ref): Either<Error, Ref> =>
 	fromString(`${ref.$ref}/${parts.join('/')}`);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,10 +1,8 @@
 import { array, uniq, flatten, last } from 'fp-ts/lib/Array';
 import { constant, Endomorphism, identity, tuple } from 'fp-ts/lib/function';
 import { getStructEq, eqString } from 'fp-ts/lib/Eq';
-import { FSEntity } from './fs';
 import { alt, map, mapNullable, option, Option, some, chain, getOrElse } from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { SwaggerObject } from '../schema/2.0/swagger-object';
 import { Dictionary } from './types';
 import { Reference, ReferenceObject } from '../schema/2.0/reference-object';
 import { QueryParameterObject } from '../schema/2.0/parameter-object/query-parameter-object/query-parameter-object';
@@ -15,10 +13,6 @@ import { OperationObject } from '../schema/2.0/operation-object';
 import { PathItemObject } from '../schema/2.0/path-item-object';
 import { PathsObject } from '../schema/2.0/paths-object';
 import { ParametersDefinitionsObject } from '../schema/2.0/parameters-definitions-object';
-
-export interface Serializer {
-	(name: string, schema: SwaggerObject): FSEntity;
-}
 
 export const getOperationsFromPath = (path: PathItemObject): Dictionary<OperationObject> => {
 	const result: Record<string, OperationObject> = {};

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,7 +2,7 @@ import { serialize as serializeSwagger2 } from '../src/language/typescript/2.0-r
 import * as path from 'path';
 import { SwaggerObject } from '../src/schema/2.0/swagger-object';
 import { generate } from '../src';
-import { Either, right } from 'fp-ts/lib/Either';
+import { Either } from 'fp-ts/lib/Either';
 import { serialize as serializeOpenAPI3 } from '../src/language/typescript/3.0-rx';
 import { OpenapiObjectCodec } from '../src/schema/3.0/openapi-object';
 import * as del from 'del';
@@ -17,14 +17,14 @@ const out = path.resolve(cwd, 'out');
 const test1 = generate({
 	spec: path.resolve(__dirname, 'specs/json/swagger.json'),
 	out,
-	language: (out, documents) => right(serializeSwagger2(out, documents)),
+	language: (out, documents) => serializeSwagger2(out, documents),
 	decoder: SwaggerObject,
 });
 
 const test2 = generate({
 	spec: path.resolve(__dirname, 'specs/yaml/swagger.yml'),
 	out,
-	language: (out, documents) => right(serializeSwagger2(out, documents)),
+	language: (out, documents) => serializeSwagger2(out, documents),
 	decoder: SwaggerObject,
 });
 


### PR DESCRIPTION
`throw` inside `serializeSchemaObject` was replaced with `Either`

BREAKING CHANGE: `typescript 2.0-rx` language is now wrapped in `Either`