### PR TITLE
feat: oneOf support for typescript openapi 3

### DIFF
--- a/src/schema/3.0/schema-object.ts
+++ b/src/schema/3.0/schema-object.ts
@@ -69,8 +69,30 @@ export const AllOfSchemaObjectCodec: Codec<AllOfSchemaObject> = recursion('AllOf
 	}),
 );
 
-export type SchemaObject = PrimitiveSchemaObject | ObjectSchemaObject | ArraySchemaObject | AllOfSchemaObject;
+export interface OneOfSchemaObject extends BaseSchemaObject {
+	readonly oneOf: NonEmptyArray<ReferenceObject | SchemaObject>;
+}
+
+export const OneOfSchemaObjectCodec: Codec<OneOfSchemaObject> = recursion('OneOfSchemaObject', () =>
+	type({
+		...BaseSchemaObjectProps,
+		oneOf: nonEmptyArray(union([ReferenceObjectCodec, SchemaObjectCodec])),
+	}),
+);
+
+export type SchemaObject =
+	| PrimitiveSchemaObject
+	| ObjectSchemaObject
+	| ArraySchemaObject
+	| AllOfSchemaObject
+	| OneOfSchemaObject;
 
 export const SchemaObjectCodec: Codec<SchemaObject> = recursion('SchemaObject', () =>
-	union([PrimitiveSchemaObjectCodec, ObjectSchemaObjectCodec, ArraySchemaObjectCodec, AllOfSchemaObjectCodec]),
+	union([
+		PrimitiveSchemaObjectCodec,
+		ObjectSchemaObjectCodec,
+		ArraySchemaObjectCodec,
+		AllOfSchemaObjectCodec,
+		OneOfSchemaObjectCodec,
+	]),
 );


### PR DESCRIPTION
BREAKING CHANGE: OneOfSchemaObject type was added to SchemaObject

closes #65 

- [ ] change target branch to `master` after #65 