### PR TITLE
feat: type codec names for swagger 2.0

### DIFF
--- a/src/language/typescript/2.0/serializers/__tests__/schema-object.spec.ts
+++ b/src/language/typescript/2.0/serializers/__tests__/schema-object.spec.ts
@@ -34,7 +34,7 @@ describe('SchemaObject serializer', () => {
 							ref,
 							getSerializedRefType(ref),
 							getSerializedOptionPropertyType('recursive', true),
-							getSerializedObjectType(),
+							getSerializedObjectType(ref.name),
 							getSerializedRecursiveType(ref, true),
 						);
 						const serialized = pipe(
@@ -68,9 +68,9 @@ describe('SchemaObject serializer', () => {
 							ref,
 							getSerializedRefType(ref),
 							getSerializedOptionPropertyType('recursive', true),
-							getSerializedObjectType(),
+							getSerializedObjectType(ref.name),
 							getSerializedOptionPropertyType('children', true),
-							getSerializedObjectType(),
+							getSerializedObjectType(ref.name),
 							getSerializedRecursiveType(ref, true),
 						);
 						const serialized = pipe(
@@ -112,7 +112,7 @@ describe('SchemaObject serializer', () => {
 							ref,
 							getSerializedRefType(ref),
 							getSerializedOptionPropertyType('self', true),
-							getSerializedObjectType(),
+							getSerializedObjectType(ref.name),
 							serialized => getSerializedIntersectionType([SERIALIZED_STRING_TYPE, serialized]),
 							getSerializedRecursiveType(ref, true),
 						);
@@ -154,9 +154,9 @@ describe('SchemaObject serializer', () => {
 							ref,
 							getSerializedRefType(ref),
 							getSerializedOptionPropertyType('self', true),
-							getSerializedObjectType(),
+							getSerializedObjectType(ref.name),
 							getSerializedOptionPropertyType('nested', true),
-							getSerializedObjectType(),
+							getSerializedObjectType(ref.name),
 							serialized => getSerializedIntersectionType([SERIALIZED_STRING_TYPE, serialized]),
 							getSerializedRecursiveType(ref, true),
 						);

--- a/src/language/typescript/2.0/serializers/schema-object.ts
+++ b/src/language/typescript/2.0/serializers/schema-object.ts
@@ -111,7 +111,7 @@ const serializeSchemaObjectWithRecursion = (
 							}),
 							sequenceEither,
 							either.map(s => intercalateSerializedTypes(serializedType(';', ',', [], []), s)),
-							either.map(getSerializedObjectType()),
+							either.map(getSerializedObjectType(from.name)),
 							either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
 						),
 					),


### PR DESCRIPTION
adds definition name to `type` as a second argument, e.g. 
```typescript
export const CategoryIO = 
  type({ id: optionFromNullable(integer), name: optionFromNullable(string) }, 'Category');
```