### PR TITLE
fix: support windows os environment

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -45,8 +45,9 @@ export type FSEntity = File | Directory | Fragment;
 export const write = async (destination: string, entity: FSEntity): Promise<void> => {
 	switch (entity.type) {
 		case 'FILE': {
-			const filePath = path.resolve(destination, entity.name);
-			await fs.writeFile(filePath, entity.content);
+			const normalizedEntityName = normalizeFilePath(entity.name);
+			const filePath = path.resolve(destination, normalizedEntityName);
+			await fs.outputFile(filePath, entity.content);
 			break;
 		}
 		case 'DIRECTORY': {
@@ -98,3 +99,6 @@ const flatten = (entities: FSEntity[]): FSEntity[] =>
 		(acc, entity) => (entity.type === 'FRAGMENT' ? acc.concat(...entity.content) : acc.concat(entity)),
 		array.array.zero<FSEntity>(),
 	);
+
+const normalizeFilePath = (filePath: string): string =>
+	filePath.startsWith(path.sep) ? normalizeFilePath(filePath.slice(1)) : filePath;

--- a/src/utils/ref.ts
+++ b/src/utils/ref.ts
@@ -86,7 +86,9 @@ export const getRelativePath = (from: Ref, to: Ref): string => {
 	const toSelf = path.relative(path.dirname(from.path), '/');
 	const toRoot = to.target === '' ? toSelf : path.join('..', toSelf);
 	const joined = path.join(toRoot, to.target, to.path);
-	return joined.startsWith('..') ? joined : `./${joined}`;
+	const joinedWithProperSeparator =
+		path.sep === path.posix.sep ? joined : joined.split(path.sep).join(path.posix.sep);
+	return joinedWithProperSeparator.startsWith('..') ? joinedWithProperSeparator : `./${joinedWithProperSeparator}`;
 };
 
 export const getFullPath = (ref: Ref): string => path.join(ref.target, ref.path);


### PR DESCRIPTION
Hello guys!
Last night i've encountered weird errors while trying to generate controllers from proper swagger spec (btw that was first time of using fresh package of codegen). Needless to say i've been running this code on my machine under windows 10 x64. So error messages haven't been verbose and only stated that file  `ROOTDISK:\\client\\client.ts` wasn't found (ENOENT).
After researching a little bit i've made a conclusion that there are some issues with path resolving:
1) `src\utils\fs.ts`:

- in `write` util when entity type is "FILE" and entity name is kinda like `\\client\\client` path resolved incorrectly. I mean path resolution working right from NodeJS' point of view following the docs ( https://nodejs.org/api/path.html#path_path_resolve_paths ): resolving from right-to-left if part of path starts with path separator it's resolved to the root, ignoring left parts of expression;
- same util - i suggest to use `outputFile` method from `fs-extra` package as it's automatically creates destination path for you, no need to ensure that given path exists before dumping output to file;

2) `src\utils\ref.ts`:

- `getRelativePath` util generates paths with OS-specific path separators which leads to issues with import/require section in autogenerated controllers under Windows OS. So i think it's better to ensure that POSIX-style path separators are used;

That all, folks! 😆 
All tests are passed, build emitted succesfully, but i didn't tested modified code against *nix machines, so as always please review with care.

