### PR TITLE
fix: fix '..' and '.' in spec names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ export interface GenerateOptions<A> {
 	readonly spec: string;
 	readonly decoder: Decoder<unknown, A>;
 	readonly language: (
-		out: string,
 		documents: Record<string, A>,
 		resolveRef: (ref: string) => Either<unknown, unknown>,
 	) => Either<unknown, FSEntity>;
@@ -65,10 +64,7 @@ export const generate = <A>(options: GenerateOptions<A>): TaskEither<unknown, vo
 
 		log('Writing to', out);
 
-		await write(
-			out,
-			getUnsafe(options.language(out, specs, ref => either.tryCatch(() => $refs.get(ref), identity))),
-		);
+		await write(out, getUnsafe(options.language(specs, ref => either.tryCatch(() => $refs.get(ref), identity))));
 
 		log('Done');
 	}, identity);

--- a/src/language/typescript/2.0/index.ts
+++ b/src/language/typescript/2.0/index.ts
@@ -1,6 +1,6 @@
 import { SwaggerObject } from '../../../schema/2.0/swagger-object';
 import { defaultPrettierConfig, SerializeOptions } from '../common/utils';
-import { directory, FSEntity, map } from '../../../utils/fs';
+import { fragment, FSEntity, map } from '../../../utils/fs';
 import { Dictionary } from '../../../utils/types';
 import { either, record } from 'fp-ts';
 import { pipe } from 'fp-ts/lib/pipeable';
@@ -13,7 +13,6 @@ import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 export const serialize = combineReader(
 	serializeSwaggerObject,
 	serializeSwaggerObject => (
-		out: string,
 		documents: Dictionary<SwaggerObject>,
 		options: SerializeOptions = {},
 	): Either<Error, FSEntity> =>
@@ -21,9 +20,8 @@ export const serialize = combineReader(
 			documents,
 			record.collect(serializeSwaggerObject),
 			sequenceEither,
-			either.map(serialized => directory(out, serialized)),
 			either.map(serialized =>
-				map(serialized, content => format(content, options.prettierConfig || defaultPrettierConfig)),
+				map(fragment(serialized), content => format(content, options.prettierConfig || defaultPrettierConfig)),
 			),
 		),
 );

--- a/src/language/typescript/3.0/index.ts
+++ b/src/language/typescript/3.0/index.ts
@@ -1,6 +1,6 @@
 import { serializeDocument } from './serializers/document';
 import { format } from 'prettier';
-import { directory, FSEntity, map as mapFS } from '../../../utils/fs';
+import { fragment, FSEntity, map as mapFS } from '../../../utils/fs';
 import { Either } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
@@ -15,7 +15,6 @@ export { serializeDocument } from './serializers/document';
 export const serialize = combineReader(
 	serializeDocument,
 	serializeDocument => (
-		out: string,
 		documents: Dictionary<OpenapiObject>,
 		options: SerializeOptions = {},
 	): Either<Error, FSEntity> =>
@@ -23,7 +22,8 @@ export const serialize = combineReader(
 			documents,
 			record.collect(serializeDocument),
 			sequenceEither,
-			either.map(serialized => directory(out, serialized)),
-			either.map(e => mapFS(e, content => format(content, options.prettierConfig || defaultPrettierConfig))),
+			either.map(e =>
+				mapFS(fragment(e), content => format(content, options.prettierConfig || defaultPrettierConfig)),
+			),
 		),
 );

--- a/src/language/typescript/asyncapi-2.0.0/index.ts
+++ b/src/language/typescript/asyncapi-2.0.0/index.ts
@@ -2,7 +2,7 @@ import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { AsyncAPIObject } from '../../../schema/asyncapi-2.0.0/asyncapi-object';
 import { defaultPrettierConfig, SerializeOptions } from '../common/utils';
 import { Either } from 'fp-ts/lib/Either';
-import { directory, FSEntity, map as mapFS } from '../../../utils/fs';
+import { fragment, FSEntity, map as mapFS } from '../../../utils/fs';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { either, record } from 'fp-ts';
 import { format } from 'prettier';
@@ -12,7 +12,6 @@ import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
 export const serialize = combineReader(
 	serializeAsyncAPIObject,
 	serializeAsyncAPIObject => (
-		out: string,
 		documents: Record<string, AsyncAPIObject>,
 		options: SerializeOptions = {},
 	): Either<Error, FSEntity> =>
@@ -20,7 +19,8 @@ export const serialize = combineReader(
 			documents,
 			record.collect(serializeAsyncAPIObject),
 			sequenceEither,
-			either.map(serialized => directory(out, serialized)),
-			either.map(e => mapFS(e, content => format(content, options.prettierConfig || defaultPrettierConfig))),
+			either.map(e =>
+				mapFS(fragment(e), content => format(content, options.prettierConfig || defaultPrettierConfig)),
+			),
 		),
 );

--- a/src/language/typescript/sketch-121/index.ts
+++ b/src/language/typescript/sketch-121/index.ts
@@ -1,5 +1,5 @@
 import { defaultPrettierConfig, SerializeOptions } from '../common/utils';
-import { directory, FSEntity, map as mapFS } from '../../../utils/fs';
+import { directory, fragment, FSEntity, map as mapFS } from '../../../utils/fs';
 import { Either } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { array, either, option, record } from 'fp-ts';
@@ -12,7 +12,6 @@ import { serializeFileFormat } from './serializers/file-format';
 export const serialize = combineReader(
 	serializeFileFormat,
 	serializeFileFormat => (
-		out: string,
 		files: Record<string, FileFormat>,
 		options: SerializeOptions = {},
 	): Either<Error, FSEntity> =>
@@ -26,7 +25,7 @@ export const serialize = combineReader(
 			),
 			sequenceEither,
 			either.map(serialized =>
-				mapFS(directory(out, array.compact(serialized)), content =>
+				mapFS(fragment(array.compact(serialized)), content =>
 					format(content, options.prettierConfig || defaultPrettierConfig),
 				),
 			),

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -46,12 +46,12 @@ export const write = async (destination: string, entity: FSEntity): Promise<void
 	switch (entity.type) {
 		case 'FILE': {
 			const normalizedEntityName = normalizeFilePath(entity.name);
-			const filePath = path.resolve(destination, normalizedEntityName);
+			const filePath = path.join(destination, normalizedEntityName);
 			await fs.outputFile(filePath, entity.content);
 			break;
 		}
 		case 'DIRECTORY': {
-			const directoryPath = path.resolve(destination, entity.name);
+			const directoryPath = path.join(destination, entity.name);
 			await fs.mkdirp(directoryPath);
 			for (const contentEntity of entity.content) {
 				await write(directoryPath, contentEntity);

--- a/test/index.ts
+++ b/test/index.ts
@@ -22,47 +22,47 @@ const out = path.resolve(cwd, 'out');
 const test1 = generate({
 	spec: path.resolve(__dirname, 'specs/2.0/json/swagger.json'),
 	out,
-	language: (out, documents, resolveRef) =>
+	language: (documents, resolveRef) =>
 		serializeSwagger2({
 			resolveRef: referenceObject => option.toUndefined(option.fromEither(resolveRef(referenceObject.$ref))),
-		})(out, documents),
+		})(documents),
 	decoder: SwaggerObject,
 });
 
 const test2 = generate({
 	spec: path.resolve(__dirname, 'specs/2.0/yaml/demo.yml'),
 	out,
-	language: (out, documents, resolveRef) =>
+	language: (documents, resolveRef) =>
 		serializeSwagger2({
 			resolveRef: referenceObject => option.toUndefined(option.fromEither(resolveRef(referenceObject.$ref))),
-		})(out, documents),
+		})(documents),
 	decoder: SwaggerObject,
 });
 
 const test3 = generate({
 	spec: path.resolve(__dirname, 'specs/3.0/demo.yml'),
 	out,
-	language: (out, documents, resolveRef) =>
+	language: (documents, resolveRef) =>
 		serializeOpenAPI3({
 			resolveRef: referenceObject => option.toUndefined(option.fromEither(resolveRef(referenceObject.$ref))),
-		})(out, documents),
+		})(documents),
 	decoder: OpenapiObjectCodec,
 });
 
 const test4 = generate({
 	spec: path.resolve(__dirname, 'specs/asyncapi-2.0.0/streetlights-api.yml'),
 	out,
-	language: (out, documents, resolveRef) =>
+	language: (documents, resolveRef) =>
 		serializeAsyncAPI({
 			resolveRef: referenceObject => option.toUndefined(option.fromEither(resolveRef(referenceObject.$ref))),
-		})(out, documents),
+		})(documents),
 	decoder: AsyncAPIObjectCodec,
 });
 
 const test5 = generate({
 	spec: path.resolve(__dirname, 'specs/sketch/demo.sketch'),
 	out,
-	language: (out1, documents) => serializeSketch({ nameStorage: createNameStorage() })(out, documents),
+	language: documents => serializeSketch({ nameStorage: createNameStorage() })(documents),
 	decoder: FileFormatCodec,
 });
 


### PR DESCRIPTION
BREAKING CHANGE: generate doesn't include `out` path in spec output
BREAKING CHANGE: language doesn't accept `out` path and can return `Fragment` to write to `out` directly