### PR TITLE
Support extract layers from sketch

### DIFF
--- a/src/language/typescript/sketch-121/serializers/document.ts
+++ b/src/language/typescript/sketch-121/serializers/document.ts
@@ -7,7 +7,7 @@ import { combineEither } from '@devexperts/utils/dist/adt/either.utils';
 import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { serializeSharedTextStyleContainer } from './objects/shared-text-style-container';
 import { serializeForeignLayerStyle } from './objects/foreign-layer-style';
-import { traverseNEAEither } from '../../../../utils/either';
+import { traverseNEAEither, traverseOptionEither } from '../../../../utils/either';
 import { sequenceOptionEither } from '../../../../utils/option';
 import { serializeForeignTextStyle } from './objects/foreign-text-style';
 import { Option } from 'fp-ts/lib/Option';
@@ -65,15 +65,11 @@ export const serializeDocument = combineReader(
 			either.map(option.map(assets => file('assets.ts', assets))),
 		);
 
-		const layers = pipe(
-			nonEmptyArray.fromArray(document.pages),
-			option.map(pages =>
-				pipe(
-					traverseNEAEither(pages, serializePage),
-					either.map(pagesLayers => file('layers.ts', pagesLayers.join(''))),
-				),
+		const layers = traverseOptionEither(nonEmptyArray.fromArray(document.pages), pages =>
+			pipe(
+				traverseNEAEither(pages, serializePage),
+				either.map(pagesLayers => file('layers.ts', pagesLayers.join(''))),
 			),
-			sequenceOptionEither,
 		);
 
 		return combineEither(

--- a/src/language/typescript/sketch-121/serializers/pages/layer.ts
+++ b/src/language/typescript/sketch-121/serializers/pages/layer.ts
@@ -1,0 +1,46 @@
+import { Layer } from '../../../../../schema/sketch-121/pages/layer';
+import { Either } from 'fp-ts/lib/Either';
+import { getJSDoc } from '../../../common/utils';
+import { serializeStyle } from '../objects/style';
+import { combineEither } from '@devexperts/utils/dist/adt/either.utils';
+import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
+import { context } from '../../utils';
+import { option, either } from 'fp-ts';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { traverseArrayEither } from '../../../../../utils/either';
+import { sequenceOptionEither } from '../../../../../utils/option';
+import { identity, constant } from 'fp-ts/lib/function';
+
+export const serializeLayer = combineReader(context, context => (layer: Layer, jsdoc?: string[]): Either<
+	Error,
+	string
+> => {
+	const safeName = 'layer_' + context.nameStorage.getSafeName(layer.do_objectID, layer.name);
+	const layerStyle = serializeStyle(layer.style);
+
+	const nestedLayersStyles = pipe(
+		layer.layers,
+		option.map(layers =>
+			pipe(
+				traverseArrayEither(layers, serializeLayer(context)),
+				either.map(styles => styles.join('')),
+			),
+		),
+		sequenceOptionEither,
+	);
+
+	return combineEither(
+		layerStyle,
+		nestedLayersStyles,
+		(pageStyle, nestedPagesStyles) => `
+            ${getJSDoc([...(jsdoc || []), layer.name, layer.do_objectID])}
+            export const ${safeName}:  { name: string; styles: Partial<CSSStyleDeclaration> } = {
+                name: '${layer.name}',
+                styles: {
+                    ${pageStyle}
+                },
+            };
+            ${option.fold(constant(''), identity)(nestedPagesStyles)}
+        `,
+	);
+});

--- a/src/language/typescript/sketch-121/serializers/pages/layer.ts
+++ b/src/language/typescript/sketch-121/serializers/pages/layer.ts
@@ -14,7 +14,8 @@ export const serializeLayer = combineReader(context, context => (layer: Layer, j
 	Error,
 	string
 > => {
-	const safeName = 'layer_' + context.nameStorage.getSafeName(layer.do_objectID, layer.name);
+	const layerNameWithPrefix = `layer_${layer.name}`;
+	const safeName = context.nameStorage.getSafeName(layer.do_objectID, layerNameWithPrefix);
 	const layerStyle = serializeStyle(layer.style);
 
 	const nestedLayersStyles = traverseOptionEither(layer.layers, layers =>

--- a/src/language/typescript/sketch-121/serializers/pages/layer.ts
+++ b/src/language/typescript/sketch-121/serializers/pages/layer.ts
@@ -7,8 +7,7 @@ import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { context } from '../../utils';
 import { option, either } from 'fp-ts';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { traverseArrayEither } from '../../../../../utils/either';
-import { sequenceOptionEither } from '../../../../../utils/option';
+import { traverseArrayEither, traverseOptionEither } from '../../../../../utils/either';
 import { identity, constant } from 'fp-ts/lib/function';
 
 export const serializeLayer = combineReader(context, context => (layer: Layer, jsdoc?: string[]): Either<
@@ -18,15 +17,11 @@ export const serializeLayer = combineReader(context, context => (layer: Layer, j
 	const safeName = 'layer_' + context.nameStorage.getSafeName(layer.do_objectID, layer.name);
 	const layerStyle = serializeStyle(layer.style);
 
-	const nestedLayersStyles = pipe(
-		layer.layers,
-		option.map(layers =>
-			pipe(
-				traverseArrayEither(layers, serializeLayer(context)),
-				either.map(styles => styles.join('')),
-			),
+	const nestedLayersStyles = traverseOptionEither(layer.layers, layers =>
+		pipe(
+			traverseArrayEither(layers, serializeLayer(context)),
+			either.map(styles => styles.join('')),
 		),
-		sequenceOptionEither,
 	);
 
 	return combineEither(

--- a/src/language/typescript/sketch-121/serializers/pages/page.ts
+++ b/src/language/typescript/sketch-121/serializers/pages/page.ts
@@ -1,0 +1,14 @@
+import { Page } from '../../../../../schema/sketch-121/pages/page';
+import { either } from 'fp-ts';
+import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { serializeLayer } from './layer';
+import { traverseArrayEither } from '../../../../../utils/either';
+import { Either } from 'fp-ts/lib/Either';
+
+export const serializePage = combineReader(serializeLayer, serializeLayer => (page: Page): Either<Error, string> =>
+	pipe(
+		traverseArrayEither(page.layers, serializeLayer),
+		either.map(styles => styles.join('')),
+	),
+);

--- a/src/language/typescript/sketch-121/utils.ts
+++ b/src/language/typescript/sketch-121/utils.ts
@@ -10,6 +10,13 @@ export const createNameStorage = () => {
 	const uuidToName = new Map<string, string>();
 	const nameToCounter = new Map<string, number>();
 
+	const getSafeNameWithCounter = (safeName: string): string => {
+		const counter = nameToCounter.get(safeName) || 1;
+		const nameWithCounter = safeName + counter;
+		nameToCounter.set(safeName, counter + 1);
+		return !nameToUuid.has(nameWithCounter) ? nameWithCounter : getSafeNameWithCounter(safeName);
+	}
+
 	const getSafeName = (uuid: string, name: string): string => {
 		const safeName = getSafePropertyName(name);
 		// check if we have a name for such uuid
@@ -27,11 +34,9 @@ export const createNameStorage = () => {
 			return safeName;
 		}
 		// we already have such safeName stored - increase counter and store under uuid
-		const counter = nameToCounter.get(safeName) || 1;
-		const nameWithCounter = safeName + counter;
+		const nameWithCounter = getSafeNameWithCounter(safeName);
 		nameToUuid.set(nameWithCounter, uuid);
 		uuidToName.set(uuid, nameWithCounter);
-		nameToCounter.set(safeName, counter + 1);
 		return nameWithCounter;
 	};
 

--- a/src/language/typescript/sketch-121/utils.ts
+++ b/src/language/typescript/sketch-121/utils.ts
@@ -15,7 +15,7 @@ export const createNameStorage = () => {
 		const nameWithCounter = safeName + counter;
 		nameToCounter.set(safeName, counter + 1);
 		return !nameToUuid.has(nameWithCounter) ? nameWithCounter : getSafeNameWithCounter(safeName);
-	}
+	};
 
 	const getSafeName = (uuid: string, name: string): string => {
 		const safeName = getSafePropertyName(name);

--- a/src/schema/sketch-121/abstract-document.ts
+++ b/src/schema/sketch-121/abstract-document.ts
@@ -4,11 +4,11 @@ import { array, type } from 'io-ts';
 import { SharedTextStyleContainer, SharedTextStyleContainerCodec } from './objects/shared-text-style-container';
 import { ForeignLayerStyle, ForeignLayerStyleCodec } from './objects/foreign-layer-style';
 import { ForeignTextStyle, ForeignTextStyleCodec } from './objects/foreign-text-style';
-import { UUID } from 'io-ts-types/lib/UUID';
 import { AssetCollection, AssetCollectionCodec } from './objects/asset-collection';
+import { ObjectID, ObjectIDCodec } from './objects//object-id';
 
 export interface AbstractDocument {
-	readonly do_objectID: UUID;
+	readonly do_objectID: ObjectID;
 	readonly assets: AssetCollection;
 	readonly foreignLayerStyles: ForeignLayerStyle[];
 	readonly foreignTextStyles: ForeignTextStyle[];
@@ -17,7 +17,7 @@ export interface AbstractDocument {
 }
 
 export const AbstractDocumentCodec: Codec<AbstractDocument> = type({
-	do_objectID: UUID,
+	do_objectID: ObjectIDCodec,
 	assets: AssetCollectionCodec,
 	foreignLayerStyles: array(ForeignLayerStyleCodec),
 	foreignTextStyles: array(ForeignTextStyleCodec),

--- a/src/schema/sketch-121/document.ts
+++ b/src/schema/sketch-121/document.ts
@@ -1,7 +1,7 @@
 import { Codec } from '../../utils/io-ts';
 import { array, intersection, type } from 'io-ts';
 import { AbstractDocument, AbstractDocumentCodec } from './abstract-document';
-import { Page, PageCodec } from './layers/page';
+import { Page, PageCodec } from './pages/page';
 
 export interface Document extends AbstractDocument {
 	readonly pages: Page[];

--- a/src/schema/sketch-121/layers/page.ts
+++ b/src/schema/sketch-121/layers/page.ts
@@ -1,6 +1,0 @@
-import { Codec } from '../../../utils/io-ts';
-import { type } from 'io-ts';
-
-export interface Page {}
-
-export const PageCodec: Codec<Page> = type({}, 'Page');

--- a/src/schema/sketch-121/objects/asset-collection.ts
+++ b/src/schema/sketch-121/objects/asset-collection.ts
@@ -1,13 +1,13 @@
-import { UUID } from 'io-ts-types/lib/UUID';
 import { ColorAsset, ColorAssetCodec } from './color-asset';
 import { Codec } from '../../../utils/io-ts';
 import { array, type } from 'io-ts';
 import { Color, ColorCodec } from './color';
 import { Gradient, GradientCodec } from './gradient';
 import { GradientAsset, GradientAssetCodec } from './gradient-asset';
+import { ObjectID, ObjectIDCodec } from './object-id';
 
 export interface AssetCollection {
-	readonly do_objectID: UUID;
+	readonly do_objectID: ObjectID;
 	readonly colorAssets: ColorAsset[];
 	readonly gradientAssets: GradientAsset[];
 	readonly colors: Color[];
@@ -15,7 +15,7 @@ export interface AssetCollection {
 }
 
 export const AssetCollectionCodec: Codec<AssetCollection> = type({
-	do_objectID: UUID,
+	do_objectID: ObjectIDCodec,
 	colorAssets: array(ColorAssetCodec),
 	gradientAssets: array(GradientAssetCodec),
 	colors: array(ColorCodec),

--- a/src/schema/sketch-121/objects/color-asset.ts
+++ b/src/schema/sketch-121/objects/color-asset.ts
@@ -1,17 +1,17 @@
 import { Color, ColorCodec } from './color';
 import { Codec } from '../../../utils/io-ts';
 import { string, type } from 'io-ts';
-import { UUID } from 'io-ts-types/lib/UUID';
+import { ObjectID, ObjectIDCodec } from './object-id';
 
 export interface ColorAsset {
-	readonly do_objectID: UUID;
+	readonly do_objectID: ObjectID;
 	readonly name: string;
 	readonly color: Color;
 }
 
 export const ColorAssetCodec: Codec<ColorAsset> = type(
 	{
-		do_objectID: UUID,
+		do_objectID: ObjectIDCodec,
 		name: string,
 		color: ColorCodec,
 	},

--- a/src/schema/sketch-121/objects/gradient-asset.ts
+++ b/src/schema/sketch-121/objects/gradient-asset.ts
@@ -1,16 +1,16 @@
 import { Gradient, GradientCodec } from './gradient';
 import { Codec } from '../../../utils/io-ts';
 import { string, type } from 'io-ts';
-import { UUID } from 'io-ts-types/lib/UUID';
+import { ObjectID, ObjectIDCodec } from './object-id';
 
 export interface GradientAsset {
-	readonly do_objectID: UUID;
+	readonly do_objectID: ObjectID;
 	readonly name: string;
 	readonly gradient: Gradient;
 }
 
 export const GradientAssetCodec: Codec<GradientAsset> = type({
-	do_objectID: UUID,
+	do_objectID: ObjectIDCodec,
 	name: string,
 	gradient: GradientCodec,
 });

--- a/src/schema/sketch-121/objects/object-id.ts
+++ b/src/schema/sketch-121/objects/object-id.ts
@@ -1,0 +1,11 @@
+import { brand, Branded, string } from 'io-ts';
+
+const UUIDReg = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+const ObjectIDReg = new RegExp(`${UUIDReg.source}(\\[${UUIDReg.source}\\])?`, 'i');
+
+interface ObjectIDBrand {
+	readonly ObjectID: unique symbol;
+}
+export type ObjectID = Branded<string, ObjectIDBrand>;
+
+export const ObjectIDCodec = brand(string, (n): n is ObjectID => ObjectIDReg.test(n), 'ObjectID');

--- a/src/schema/sketch-121/objects/shared-style.ts
+++ b/src/schema/sketch-121/objects/shared-style.ts
@@ -1,10 +1,10 @@
 import { Codec } from '../../../utils/io-ts';
 import { string, type } from 'io-ts';
-import { UUID } from 'io-ts-types/lib/UUID';
 import { Style, StyleCodec } from './style';
+import { ObjectID, ObjectIDCodec } from './object-id';
 
 export interface SharedStyle {
-	readonly do_objectID: UUID;
+	readonly do_objectID: ObjectID;
 	readonly name: string;
 	readonly value: Style;
 }
@@ -12,7 +12,7 @@ export interface SharedStyle {
 export const SharedStyleCodec: Codec<SharedStyle> = type(
 	{
 		name: string,
-		do_objectID: UUID,
+		do_objectID: ObjectIDCodec,
 		value: StyleCodec,
 	},
 	'SharedStyle',

--- a/src/schema/sketch-121/objects/style.ts
+++ b/src/schema/sketch-121/objects/style.ts
@@ -1,4 +1,3 @@
-import { UUID } from 'io-ts-types/lib/UUID';
 import { Codec } from '../../../utils/io-ts';
 import { array, type } from 'io-ts';
 import { Option } from 'fp-ts/lib/Option';
@@ -10,9 +9,10 @@ import { BorderOptions, BorderOptionsCodec } from './border-options';
 import { InnerShadow, InnerShadowCodec } from './inner-shadow';
 import { Shadow, ShadowCodec } from './shadow';
 import { TextStyle, TextStyleCodec } from './text-style';
+import { ObjectID, ObjectIDCodec } from './object-id';
 
 export interface Style {
-	readonly do_objectID: UUID;
+	readonly do_objectID: ObjectID;
 	readonly borders: Option<Border[]>;
 	readonly borderOptions: BorderOptions;
 	readonly fills: Option<Fill[]>;
@@ -24,7 +24,7 @@ export interface Style {
 
 export const StyleCodec: Codec<Style> = type(
 	{
-		do_objectID: UUID,
+		do_objectID: ObjectIDCodec,
 		borders: optionFromNullable(array(BorderCodec)),
 		borderOptions: BorderOptionsCodec,
 		fills: optionFromNullable(array(FillCodec)),

--- a/src/schema/sketch-121/pages/layer.ts
+++ b/src/schema/sketch-121/pages/layer.ts
@@ -1,0 +1,29 @@
+import { Codec } from '../../../utils/io-ts';
+import { Style, StyleCodec } from '../objects/style';
+import { ObjectID, ObjectIDCodec } from '../objects/object-id';
+import { string, type, array, recursion, boolean } from 'io-ts';
+import { optionFromNullable } from 'io-ts-types/lib/optionFromNullable';
+import { Option } from 'fp-ts/lib/Option';
+
+export interface Layer {
+	readonly _class: string;
+	readonly do_objectID: ObjectID;
+	readonly name: string;
+	readonly style: Style;
+	readonly layers: Option<Layer[]>;
+	readonly isVisible: boolean;
+}
+
+export const LayerCodec: Codec<Layer> = recursion('Layer', () =>
+	type(
+		{
+			_class: string,
+			do_objectID: ObjectIDCodec,
+			name: string,
+			style: StyleCodec,
+			isVisible: boolean,
+			layers: optionFromNullable(array(LayerCodec)),
+		},
+		'Layer',
+	),
+);

--- a/src/schema/sketch-121/pages/page.ts
+++ b/src/schema/sketch-121/pages/page.ts
@@ -1,0 +1,22 @@
+import { Codec } from '../../../utils/io-ts';
+import { Style, StyleCodec } from '../objects/style';
+import { ObjectID, ObjectIDCodec } from '../objects/object-id';
+import { string, type, array } from 'io-ts';
+import { Layer, LayerCodec } from './layer';
+
+export interface Page {
+	do_objectID: ObjectID;
+	name: string;
+	style: Style;
+	layers: Layer[];
+}
+
+export const PageCodec: Codec<Page> = type(
+	{
+		do_objectID: ObjectIDCodec,
+		name: string,
+		style: StyleCodec,
+		layers: array(LayerCodec),
+	},
+	'Page',
+);

--- a/src/utils/either.ts
+++ b/src/utils/either.ts
@@ -1,4 +1,5 @@
-import { either, array, nonEmptyArray } from 'fp-ts';
+import { either, array, nonEmptyArray, option } from 'fp-ts';
 
 export const traverseArrayEither = array.array.traverse(either.either);
 export const traverseNEAEither = nonEmptyArray.nonEmptyArray.traverse(either.either);
+export const traverseOptionEither = option.option.traverse(either.either);


### PR DESCRIPTION
Added extraction of layers and their styles from sketch file.
Also corrected getting safe name in name storage for avoid collision, e.g. when we have 3 objects - `{ uuid: 1, name: 'name'}, {uuid: 2, name: 'name1' }, {uuid: 3, name: 'name' `}. In past flow name storage will return names - `'name', 'name1', 'name1'.` Now it will be` 'name', 'name1', 'name2'`.