### PR TITLE
feat: expand sketch schema for support foreign symbols

### DIFF
--- a/src/language/typescript/common/utils.ts
+++ b/src/language/typescript/common/utils.ts
@@ -59,6 +59,10 @@ export const getKindValue = (kind: Kind, value: string): string => {
 
 export const getControllerName = (name: string): string => `${name}Controller`;
 
+const COMMENT_PATTERN = /\/\*(.*)\*\//;
+const REPLACE_COMMENT_PATTERN = new RegExp(COMMENT_PATTERN, 'g');
+export const escapeCommpent = (value: string) => value.replace(REPLACE_COMMENT_PATTERN, '\\/*$1*\\/');
+
 export const UNSAFE_PROPERTY_PATTERN = /[^a-zA-Z_0-9]/;
 const REPLACE_PATTERN = new RegExp(UNSAFE_PROPERTY_PATTERN, 'g');
 export const getSafePropertyName = (value: string): string =>

--- a/src/language/typescript/sketch-121/serializers/document.ts
+++ b/src/language/typescript/sketch-121/serializers/document.ts
@@ -13,7 +13,7 @@ import { serializeForeignTextStyle } from './objects/foreign-text-style';
 import { Option } from 'fp-ts/lib/Option';
 import { file, fragment, FSEntity } from '../../../../utils/fs';
 import { serializeAssetCollection } from './objects/asset-collection';
-import { serializePage } from './pages/page';
+import { serializePage } from './objects/page';
 
 export const serializeDocument = combineReader(
 	serializeSharedStyleContainer,

--- a/src/language/typescript/sketch-121/serializers/objects/layer.ts
+++ b/src/language/typescript/sketch-121/serializers/objects/layer.ts
@@ -1,7 +1,7 @@
-import { Layer } from '../../../../../schema/sketch-121/pages/layer';
+import { Layer } from '../../../../../schema/sketch-121/objects/layer';
 import { Either } from 'fp-ts/lib/Either';
-import { getJSDoc } from '../../../common/utils';
-import { serializeStyle } from '../objects/style';
+import { getJSDoc, escapeCommpent } from '../../../common/utils';
+import { serializeStyle } from './style';
 import { combineEither } from '@devexperts/utils/dist/adt/either.utils';
 import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { context } from '../../utils';
@@ -29,7 +29,7 @@ export const serializeLayer = combineReader(context, context => (layer: Layer, j
 		layerStyle,
 		nestedLayersStyles,
 		(pageStyle, nestedPagesStyles) => `
-            ${getJSDoc([...(jsdoc || []), layer.name, layer.do_objectID])}
+            ${getJSDoc([...(jsdoc || []), escapeCommpent(layer.name), layer.do_objectID])}
             export const ${safeName}:  { name: string; styles: Partial<CSSStyleDeclaration> } = {
                 name: '${layer.name}',
                 styles: {

--- a/src/language/typescript/sketch-121/serializers/objects/page.ts
+++ b/src/language/typescript/sketch-121/serializers/objects/page.ts
@@ -1,4 +1,4 @@
-import { Page } from '../../../../../schema/sketch-121/pages/page';
+import { Page } from '../../../../../schema/sketch-121/objects/page';
 import { either } from 'fp-ts';
 import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { pipe } from 'fp-ts/lib/pipeable';

--- a/src/schema/sketch-121/abstract-document.ts
+++ b/src/schema/sketch-121/abstract-document.ts
@@ -5,13 +5,15 @@ import { SharedTextStyleContainer, SharedTextStyleContainerCodec } from './objec
 import { ForeignLayerStyle, ForeignLayerStyleCodec } from './objects/foreign-layer-style';
 import { ForeignTextStyle, ForeignTextStyleCodec } from './objects/foreign-text-style';
 import { AssetCollection, AssetCollectionCodec } from './objects/asset-collection';
-import { ObjectID, ObjectIDCodec } from './objects//object-id';
+import { ObjectID, ObjectIDCodec } from './objects/object-id';
+import { ForeignSymbol, ForeignSymbolCodec } from './objects/foreign-symbol';
 
 export interface AbstractDocument {
 	readonly do_objectID: ObjectID;
 	readonly assets: AssetCollection;
 	readonly foreignLayerStyles: ForeignLayerStyle[];
 	readonly foreignTextStyles: ForeignTextStyle[];
+	readonly foreignSymbols: ForeignSymbol[];
 	readonly layerTextStyles: SharedTextStyleContainer;
 	readonly layerStyles: SharedStyleContainer;
 }
@@ -21,6 +23,7 @@ export const AbstractDocumentCodec: Codec<AbstractDocument> = type({
 	assets: AssetCollectionCodec,
 	foreignLayerStyles: array(ForeignLayerStyleCodec),
 	foreignTextStyles: array(ForeignTextStyleCodec),
+	foreignSymbols: array(ForeignSymbolCodec),
 	layerTextStyles: SharedTextStyleContainerCodec,
 	layerStyles: SharedStyleContainerCodec,
 });

--- a/src/schema/sketch-121/document.ts
+++ b/src/schema/sketch-121/document.ts
@@ -1,7 +1,7 @@
 import { Codec } from '../../utils/io-ts';
 import { array, intersection, type } from 'io-ts';
 import { AbstractDocument, AbstractDocumentCodec } from './abstract-document';
-import { Page, PageCodec } from './pages/page';
+import { Page, PageCodec } from './objects/page';
 
 export interface Document extends AbstractDocument {
 	readonly pages: Page[];

--- a/src/schema/sketch-121/enums/layer-class.ts
+++ b/src/schema/sketch-121/enums/layer-class.ts
@@ -1,0 +1,28 @@
+import { literal, union } from 'io-ts';
+import { Codec } from '../../../utils/io-ts';
+
+export type LayerClass =
+	| 'symbolInstance'
+	| 'symbolMaster'
+	| 'group'
+	| 'oval'
+	| 'text'
+	| 'rectangle'
+	| 'shapePath'
+	| 'shapeGroup'
+	| 'artboard';
+
+export const LayerClassCodec: Codec<LayerClass> = union(
+	[
+		literal('symbolInstance'),
+		literal('symbolMaster'),
+		literal('group'),
+		literal('oval'),
+		literal('text'),
+		literal('rectangle'),
+		literal('shapePath'),
+		literal('shapeGroup'),
+		literal('artboard'),
+	],
+	'LayerClass',
+);

--- a/src/schema/sketch-121/meta.ts
+++ b/src/schema/sketch-121/meta.ts
@@ -1,13 +1,13 @@
 import { Codec } from '../../utils/io-ts';
-import { literal, type } from 'io-ts';
+import { literal, type, union } from 'io-ts';
 
 export interface Meta {
-	readonly version: 121;
+	readonly version: 121 | 122 | 123;
 }
 
 export const MetaCodec: Codec<Meta> = type(
 	{
-		version: literal(121),
+		version: union([literal(121), literal(122), literal(123)]),
 	},
 	'Meta',
 );

--- a/src/schema/sketch-121/objects/foreign-symbol.ts
+++ b/src/schema/sketch-121/objects/foreign-symbol.ts
@@ -1,0 +1,19 @@
+import { type } from 'io-ts';
+import { Layer, LayerCodec } from './layer';
+import { ObjectID, ObjectIDCodec } from './object-id';
+import { Codec } from '../../../utils/io-ts';
+
+export interface ForeignSymbol {
+	do_objectID: ObjectID;
+	originalMaster: Layer;
+	symbolMaster: Layer;
+}
+
+export const ForeignSymbolCodec: Codec<ForeignSymbol> = type(
+	{
+		do_objectID: ObjectIDCodec,
+		originalMaster: LayerCodec,
+		symbolMaster: LayerCodec,
+	},
+	'ForeignSymbol',
+);

--- a/src/schema/sketch-121/objects/layer.ts
+++ b/src/schema/sketch-121/objects/layer.ts
@@ -1,28 +1,36 @@
 import { Codec } from '../../../utils/io-ts';
-import { Style, StyleCodec } from '../objects/style';
-import { ObjectID, ObjectIDCodec } from '../objects/object-id';
+import { Style, StyleCodec } from './style';
+import { ObjectID, ObjectIDCodec } from './object-id';
 import { string, type, array, recursion, boolean } from 'io-ts';
 import { optionFromNullable } from 'io-ts-types/lib/optionFromNullable';
 import { Option } from 'fp-ts/lib/Option';
+import { OverrideValue, OverrideValueCodec } from './override-value';
+import { LayerClass, LayerClassCodec } from '../enums/layer-class';
 
 export interface Layer {
-	readonly _class: string;
+	readonly _class: LayerClass;
 	readonly do_objectID: ObjectID;
 	readonly name: string;
 	readonly style: Style;
 	readonly layers: Option<Layer[]>;
 	readonly isVisible: boolean;
+	readonly overrideValues: Option<OverrideValue[]>;
+	readonly sharedStyleID: Option<ObjectID>;
+	readonly symbolID: Option<ObjectID>;
 }
 
 export const LayerCodec: Codec<Layer> = recursion('Layer', () =>
 	type(
 		{
-			_class: string,
+			_class: LayerClassCodec,
 			do_objectID: ObjectIDCodec,
 			name: string,
 			style: StyleCodec,
 			isVisible: boolean,
 			layers: optionFromNullable(array(LayerCodec)),
+			overrideValues: optionFromNullable(array(OverrideValueCodec)),
+			sharedStyleID: optionFromNullable(ObjectIDCodec),
+			symbolID: optionFromNullable(ObjectIDCodec),
 		},
 		'Layer',
 	),

--- a/src/schema/sketch-121/objects/override-value.ts
+++ b/src/schema/sketch-121/objects/override-value.ts
@@ -1,0 +1,17 @@
+import { string, type } from 'io-ts';
+import { Codec } from '../../../utils/io-ts';
+
+export interface OverrideValue {
+	readonly _class: string;
+	readonly overrideName: string;
+	readonly value: string;
+}
+
+export const OverrideValueCodec: Codec<OverrideValue> = type(
+	{
+		_class: string,
+		value: string,
+		overrideName: string,
+	},
+	'OverrideValue',
+);

--- a/src/schema/sketch-121/objects/page.ts
+++ b/src/schema/sketch-121/objects/page.ts
@@ -1,6 +1,6 @@
 import { Codec } from '../../../utils/io-ts';
-import { Style, StyleCodec } from '../objects/style';
-import { ObjectID, ObjectIDCodec } from '../objects/object-id';
+import { Style, StyleCodec } from './style';
+import { ObjectID, ObjectIDCodec } from './object-id';
 import { string, type, array } from 'io-ts';
 import { Layer, LayerCodec } from './layer';
 


### PR DESCRIPTION
Improvements of sketch schema:
- Specified class of layers in more detail
- Added foreign symbols in document
Also added comment encoding in layer name and changed schema version to 123 without breaking changes