### PR TITLE
feat: support date type

### DIFF
--- a/src/language/typescript/2.0/serializers/swagger-object.ts
+++ b/src/language/typescript/2.0/serializers/swagger-object.ts
@@ -12,6 +12,7 @@ import { clientFile } from '../../common/bundled/client';
 import { serializeParametersDefinitionsObject } from './parameters-definitions-object';
 import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { serializeResponsesDefinitionsObject } from './responses-definitions-object';
+import { utilsFile } from '../../common/bundled/utils';
 
 const definitionsRef = fromString('#/definitions');
 const parametersRef = fromString('#/parameters');
@@ -52,8 +53,8 @@ export const serializeSwaggerObject = combineReader(
 			pathsRef,
 			either.chain(from => serializePaths(from, swaggerObject.paths)),
 		);
-		return combineEither(additional, paths, clientFile, (additional, paths, clientFile) =>
-			directory(name, [clientFile, ...additional, paths]),
+		return combineEither(additional, paths, clientFile, utilsFile, (additional, paths, clientFile, utilsFile) =>
+			directory(name, [clientFile, ...additional, utilsFile, paths]),
 		);
 	},
 );

--- a/src/language/typescript/3.0/serializers/document.ts
+++ b/src/language/typescript/3.0/serializers/document.ts
@@ -12,6 +12,7 @@ import { OpenapiObject } from '../../../../schema/3.0/openapi-object';
 import { pathsRef } from '../../common/utils';
 import { clientFile } from '../../common/bundled/client';
 import { openapi3utilsFile } from '../bundled/openapi-3-utils';
+import { utilsFile } from '../../common/bundled/utils';
 
 export const serializeDocument = combineReader(
 	serializeComponentsObject,
@@ -36,9 +37,10 @@ export const serializeDocument = combineReader(
 			paths,
 			additional,
 			clientFile,
+			utilsFile,
 			openapi3utilsFile,
-			(paths, additional, clientFile, openapi3utilsFile) =>
-				directory(name, [paths, ...additional, clientFile, openapi3utilsFile]),
+			(paths, additional, clientFile, utilsFile, openapi3utilsFile) =>
+				directory(name, [paths, ...additional, clientFile, utilsFile, openapi3utilsFile]),
 		);
 	},
 );

--- a/src/language/typescript/asyncapi-2.0.0/serializers/asyncapi-object.ts
+++ b/src/language/typescript/asyncapi-2.0.0/serializers/asyncapi-object.ts
@@ -9,6 +9,7 @@ import { array, either, option } from 'fp-ts';
 import { combineEither, sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
 import { serializeChannelsObject } from './channels-object';
 import { clientFile } from '../../common/bundled/client';
+import { utilsFile } from '../../common/bundled/utils';
 
 export const serializeAsyncAPIObject = combineReader(
 	serializeComponentsObject,
@@ -29,8 +30,13 @@ export const serializeAsyncAPIObject = combineReader(
 			either.chain(from => serializeChannelsObject(from, asyncAPIObject.channels)),
 			either.map(content => directory('channels', [content])),
 		);
-		return combineEither(channels, additional, clientFile, (channels, additional, clientFile) =>
-			directory(name, [channels, clientFile, ...additional]),
+		return combineEither(
+			channels,
+			additional,
+			clientFile,
+			utilsFile,
+			(channels, additional, clientFile, utilsFile) =>
+				directory(name, [channels, clientFile, ...additional, utilsFile]),
 		);
 	},
 );

--- a/src/language/typescript/common/bundled/utils.ts
+++ b/src/language/typescript/common/bundled/utils.ts
@@ -6,6 +6,38 @@ import { fromRef } from '../../../../utils/fs';
 export const utilsRef = fromString('#/utils/utils');
 
 const utils = `
+	import { either } from 'fp-ts/lib/Either';
+	import { Type, failure, success, string as tstring } from 'io-ts';
+
+	const getISOTimezoneOffsetString = (offsetMinutes: number): string => {
+		if (offsetMinutes === 0) {
+			return 'Z';
+		}
+
+		const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+		const offsetHours = absoluteOffsetMinutes / 60;
+		const offsetRestMinutes = absoluteOffsetMinutes % 60;
+
+		return \`\${offsetMinutes > 0 ? '-' : '+'}\${offsetHours
+			.toString()
+			.padStart(2, '0')}:\${offsetRestMinutes.toString().padStart(2, '0')}\`;
+	};
+
+	export const DateFromISODateStringIO = new Type<Date, string, unknown>(
+		'DateFromISODateString',
+		(u): u is Date => u instanceof Date,
+		(u, c) =>
+			either.chain(tstring.validate(u, c), s => {
+				const offset = new Date().getTimezoneOffset();
+				const d = new Date(\`\${s}T00:00:00\${getISOTimezoneOffsetString(offset)}\`);
+				return isNaN(d.getTime()) ? failure(u, c) : success(d);
+			}),
+		a =>
+			\`\${a.getFullYear()}-\${(a.getMonth() + 1).toString().padStart(2, '0')}-\${a
+				.getDate()
+				.toString()
+				.padStart(2, '0')}\`,
+	);
 `;
 
 export const utilsFile = pipe(

--- a/src/language/typescript/common/data/serialized-type.ts
+++ b/src/language/typescript/common/data/serialized-type.ts
@@ -73,10 +73,16 @@ export const SERIALIZED_BOOLEAN_TYPE = serializedType(
 );
 export const SERIALIZED_NUMBER_TYPE = serializedType('number', 'number', [serializedDependency('number', 'io-ts')], []);
 export const SERIALIZED_INTEGER_TYPE = serializedType('Int', 'Int', [serializedDependency('Int', 'io-ts')], []);
-export const SERIALIZED_DATE_TYPE = serializedType(
+export const SERIALIZED_DATETIME_TYPE = serializedType(
 	'Date',
 	'DateFromISOString',
 	[serializedDependency('DateFromISOString', 'io-ts-types/lib/DateFromISOString')],
+	[],
+);
+export const SERIALIZED_DATE_TYPE = serializedType(
+	'Date',
+	'DateFromISODateStringIO',
+	[serializedDependency('DateFromISODateStringIO', '../utils/utils')],
 	[],
 );
 export const SERIALIZED_STRING_TYPE = serializedType('string', 'string', [serializedDependency('string', 'io-ts')], []);
@@ -86,7 +92,9 @@ export const getSerializedStringType = (format: Option<string>): SerializedType 
 		option.chain(format => {
 			// https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
 			switch (format) {
-				case 'date-time':
+				case 'date-time': {
+					return some(SERIALIZED_DATETIME_TYPE);
+				}
 				case 'date': {
 					return some(SERIALIZED_DATE_TYPE);
 				}

--- a/test/specs/2.0/json/common.json
+++ b/test/specs/2.0/json/common.json
@@ -23,6 +23,10 @@
         },
         "shipDate": {
           "type": "string",
+          "format": "date"
+        },
+        "lastUpdate": {
+          "type": "string",
           "format": "date-time"
         },
         "status": {
@@ -34,10 +38,12 @@
             "delivered"
           ]
         },
-        "state" : {
-          "type" : "string",
-          "description" : "order state",
-          "enum" : [ "ACTIVE" ]
+        "state": {
+          "type": "string",
+          "description": "order state",
+          "enum": [
+            "ACTIVE"
+          ]
         },
         "complete": {
           "type": "boolean",

--- a/test/specs/2.0/yaml/common.yml
+++ b/test/specs/2.0/yaml/common.yml
@@ -19,6 +19,9 @@ definitions:
         format: int32
       shipDate:
         type: string
+        format: date
+      lastUpdate:
+        type: string
         format: date-time
       status:
         type: string


### PR DESCRIPTION
Added:

- io-ts codec that supports date ignoring time
- type serialization rules for `format: date` definitions
- common utils file to the output utils folder
- test case for swagger 2.0