### PR TITLE
fix: add year padding to the codec

### DIFF
--- a/src/language/typescript/common/bundled/utils.ts
+++ b/src/language/typescript/common/bundled/utils.ts
@@ -33,7 +33,7 @@ const utils = `
 				return isNaN(d.getTime()) ? failure(u, c) : success(d);
 			}),
 		a =>
-			\`\${a.getFullYear()}-\${(a.getMonth() + 1).toString().padStart(2, '0')}-\${a
+			\`\${a.getFullYear().toString().padStart(4, '0')}-\${(a.getMonth() + 1).toString().padStart(2, '0')}-\${a
 				.getDate()
 				.toString()
 				.padStart(2, '0')}\`,


### PR DESCRIPTION
Added year padding to the codec to cover the case when backend returns `0001-01-01` that should be treated as valid date