### PR TITLE
fix: incorrect generation "deprecated" jsdoc for method

### DIFF
--- a/src/language/typescript/2.0/serializers/operation-object.ts
+++ b/src/language/typescript/2.0/serializers/operation-object.ts
@@ -52,6 +52,7 @@ import {
 	SerializedFragment,
 } from '../../common/data/serialized-fragment';
 import { sequenceOptionEither } from '../../../../utils/option';
+import { identity } from 'fp-ts/lib/function';
 
 interface Parameters {
 	readonly pathParameters: PathParameterObject[];
@@ -246,6 +247,7 @@ export const serializeOperationObject = combineReader(
 
 		const deprecated = pipe(
 			operation.deprecated,
+			option.filter(identity),
 			map(() => `@deprecated`),
 		);
 

--- a/test/specs/2.0/json/swagger.json
+++ b/test/specs/2.0/json/swagger.json
@@ -49,6 +49,7 @@
         "tags": [
           "pet"
         ],
+        "deprecated": false,
         "summary": "Add a new pet to the store",
         "description": "",
         "operationId": "addPet",
@@ -149,6 +150,7 @@
         "tags": [
           "pet"
         ],
+        "deprecated": true,
         "summary": "Finds Pets by status",
         "description": "Multiple status values can be provided with comma separated strings",
         "operationId": "findPetsByStatus",


### PR DESCRIPTION
Jsdoc @deprecated added not depend on value in swagger spec.