### PR TITLE
Customize codecs

### DIFF
--- a/src/language/typescript/3.0/index.ts
+++ b/src/language/typescript/3.0/index.ts
@@ -3,27 +3,33 @@ import { format } from 'prettier';
 import { fragment, FSEntity, map as mapFS } from '../../../utils/fs';
 import { Either } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
+import { combineReader, deferReader } from '@devexperts/utils/dist/adt/reader.utils';
 import { either, record } from 'fp-ts';
 import { Dictionary } from '../../../utils/types';
 import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
 import { OpenapiObject } from '../../../schema/3.0/openapi-object';
 import { defaultPrettierConfig, SerializeOptions } from '../common/utils';
+import { serializePrimitiveDefault } from './serializers/schema-object';
 
 export { serializeDocument } from './serializers/document';
 
-export const serialize = combineReader(
-	serializeDocument,
-	serializeDocument => (
-		documents: Dictionary<OpenapiObject>,
-		options: SerializeOptions = {},
-	): Either<Error, FSEntity> =>
-		pipe(
-			documents,
-			record.collect(serializeDocument),
-			sequenceEither,
-			either.map(e =>
-				mapFS(fragment(e), content => format(content, options.prettierConfig || defaultPrettierConfig)),
+export const serializeCustom = pipe(
+	combineReader(
+		serializeDocument,
+		serializeDocument => (
+			documents: Dictionary<OpenapiObject>,
+			options: SerializeOptions = {},
+		): Either<Error, FSEntity> =>
+			pipe(
+				documents,
+				record.collect(serializeDocument),
+				sequenceEither,
+				either.map(e =>
+					mapFS(fragment(e), content => format(content, options.prettierConfig || defaultPrettierConfig)),
+				),
 			),
-		),
+	),
+	reader => deferReader(reader, 'resolveRef'),
 );
+
+export const serialize = serializeCustom({ serializePrimitive: serializePrimitiveDefault });

--- a/src/language/typescript/3.0/serializers/__tests__/schema-object.spec.ts
+++ b/src/language/typescript/3.0/serializers/__tests__/schema-object.spec.ts
@@ -1,4 +1,4 @@
-import { serializeSchemaObject } from '../schema-object';
+import { serializeSchemaObjectDefault } from '../schema-object';
 import {
 	getSerializedArrayType,
 	getSerializedDictionaryType,
@@ -50,7 +50,7 @@ describe('SchemaObject', () => {
 							},
 						],
 					});
-					const serialized = pipe(schema, reportIfFailed, either.chain(serializeSchemaObject(ref)));
+					const serialized = pipe(schema, reportIfFailed, either.chain(serializeSchemaObjectDefault(ref)));
 					pipe(
 						serialized,
 						either.fold(fail, result => {
@@ -85,10 +85,10 @@ describe('SchemaObject', () => {
 					property($refArbitrary, schema, string(), (from, schema, name) => {
 						const expected = pipe(
 							schema.items,
-							serializeSchemaObject(from, name),
+							serializeSchemaObjectDefault(from, name),
 							either.map(getSerializedArrayType(none, name)),
 						);
-						const serialized = pipe(schema, serializeSchemaObject(from, name));
+						const serialized = pipe(schema, serializeSchemaObjectDefault(from, name));
 						expect(serialized).toEqual(expected);
 					}),
 				);
@@ -107,9 +107,9 @@ describe('SchemaObject', () => {
 							getSerializedRefType(from),
 							getSerializedArrayType(none, name),
 						);
-						expect(pipe(schema, reportIfFailed, either.chain(serializeSchemaObject(from, name)))).toEqual(
-							right(expected),
-						);
+						expect(
+							pipe(schema, reportIfFailed, either.chain(serializeSchemaObjectDefault(from, name))),
+						).toEqual(right(expected));
 					}),
 				);
 			});
@@ -138,7 +138,11 @@ describe('SchemaObject', () => {
 							getSerializedObjectType(undefined),
 							getSerializedRecursiveType(ref, true),
 						);
-						const serialized = pipe(schema, reportIfFailed, either.chain(serializeSchemaObject(ref)));
+						const serialized = pipe(
+							schema,
+							reportIfFailed,
+							either.chain(serializeSchemaObjectDefault(ref)),
+						);
 
 						expect(serialized).toEqual(right(expected));
 					}),
@@ -162,7 +166,11 @@ describe('SchemaObject', () => {
 								},
 							},
 						});
-						const serialized = pipe(schema, reportIfFailed, either.chain(serializeSchemaObject(ref)));
+						const serialized = pipe(
+							schema,
+							reportIfFailed,
+							either.chain(serializeSchemaObjectDefault(ref)),
+						);
 						const expected = pipe(
 							ref,
 							getSerializedRefType(ref),
@@ -185,7 +193,11 @@ describe('SchemaObject', () => {
 								$ref: ref.$ref, // references self
 							},
 						});
-						const serialized = pipe(schema, reportIfFailed, either.chain(serializeSchemaObject(ref)));
+						const serialized = pipe(
+							schema,
+							reportIfFailed,
+							either.chain(serializeSchemaObjectDefault(ref)),
+						);
 
 						const expected = pipe(
 							ref,

--- a/src/language/typescript/3.0/serializers/operation-object.ts
+++ b/src/language/typescript/3.0/serializers/operation-object.ts
@@ -78,7 +78,13 @@ const contains = array.elem(eqParameterByNameAndIn);
 
 export const getParameters = combineReader(
 	ask<ResolveRefContext>(),
-	e => (from: Ref, operation: OperationObject, pathItem: PathItemObject): Either<Error, Parameters> => {
+	serializeParameterObject,
+	serializeRequestBodyObject,
+	(e, serializeParameterObject, serializeRequestBodyObject) => (
+		from: Ref,
+		operation: OperationObject,
+		pathItem: PathItemObject,
+	): Either<Error, Parameters> => {
 		const processedParameters: ParameterObject[] = [];
 		const pathParameters: ParameterObject[] = [];
 		const serializedPathParameters: SerializedPathParameter[] = [];
@@ -258,7 +264,8 @@ export const getParameters = combineReader(
 export const serializeOperationObject = combineReader(
 	ask<ResolveRefContext>(),
 	getParameters,
-	(e, getParameters) => (
+	serializeResponsesObject,
+	(e, getParameters, serializeResponsesObject) => (
 		pattern: string,
 		method: HTTPMethod,
 		from: Ref,

--- a/src/language/typescript/3.0/serializers/request-body-object.ts
+++ b/src/language/typescript/3.0/serializers/request-body-object.ts
@@ -14,46 +14,54 @@ import { ReferenceObjectCodec, ReferenceObject } from '../../../../schema/3.0/re
 import { SchemaObject } from '../../../../schema/3.0/schema-object';
 import { getKeyMatchValue, getResponseTypeFromMediaType, XHRResponseType } from '../../common/utils';
 import { MediaTypeObject } from '../../../../schema/3.0/media-type-object';
+import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 
 const requestMediaRegexp = /^(video|audio|image|application|text|multipart|\*)\/(\w+|\*)/;
 export const getRequestMedia = (content: Record<string, MediaTypeObject>) =>
 	getKeyMatchValue(content, requestMediaRegexp);
 
-export const serializeRequestBodyObject = (from: Ref, body: RequestBodyObject): Either<Error, SerializedType> =>
-	pipe(
-		getRequestMedia(body.content),
-		option.chain(({ key: mediaType, value: { schema } }) =>
-			pipe(
-				schema,
-				option.map(schema => ({ mediaType, schema })),
+export const serializeRequestBodyObject = combineReader(serializeSchemaObject, serializeSchemaObject => {
+	const serializeRequestBodyObject = (from: Ref, body: RequestBodyObject): Either<Error, SerializedType> =>
+		pipe(
+			getRequestMedia(body.content),
+			option.chain(({ key: mediaType, value: { schema } }) =>
+				pipe(
+					schema,
+					option.map(schema => ({ mediaType, schema })),
+				),
 			),
-		),
-		either.fromOption(() => new Error('No schema found for ReqeustBodyObject')),
-		either.chain(({ mediaType, schema }) => {
-			const resType = getResponseTypeFromMediaType(mediaType);
-			return serializeRequestSchema(resType, schema, from);
-		}),
-	);
+			either.fromOption(() => new Error('No schema found for RequestBodyObject')),
+			either.chain(({ mediaType, schema }) => {
+				const resType = getResponseTypeFromMediaType(mediaType);
+				return serializeRequestSchema(resType, schema, from);
+			}),
+		);
 
-const serializeRequestSchema = (
-	responseType: XHRResponseType,
-	schema: ReferenceObject | SchemaObject,
-	from: Ref,
-): Either<Error, SerializedType> => {
-	switch (responseType) {
-		case 'json':
-			return ReferenceObjectCodec.is(schema)
-				? pipe(
-						fromString(schema.$ref),
-						mapLeft(
-							() => new Error(`Invalid MediaObject.content.$ref "${schema.$ref}" for RequestBodyObject`),
-						),
-						either.map(getSerializedRefType(from)),
-				  )
-				: serializeSchemaObject(from)(schema);
-		case 'text':
-			return either.right(SERIALIZED_STRING_TYPE);
-		case 'blob':
-			return getSerializedBlobType(from);
-	}
-};
+	const serializeRequestSchema = (
+		responseType: XHRResponseType,
+		schema: ReferenceObject | SchemaObject,
+		from: Ref,
+	): Either<Error, SerializedType> => {
+		switch (responseType) {
+			case 'json':
+				return ReferenceObjectCodec.is(schema)
+					? pipe(
+							fromString(schema.$ref),
+							mapLeft(
+								() =>
+									new Error(
+										`Invalid MediaObject.content.$ref "${schema.$ref}" for RequestBodyObject`,
+									),
+							),
+							either.map(getSerializedRefType(from)),
+					  )
+					: serializeSchemaObject(from)(schema);
+			case 'text':
+				return either.right(SERIALIZED_STRING_TYPE);
+			case 'blob':
+				return getSerializedBlobType(from);
+		}
+	};
+
+	return serializeRequestBodyObject;
+});

--- a/src/language/typescript/3.0/serializers/response-object.ts
+++ b/src/language/typescript/3.0/serializers/response-object.ts
@@ -1,95 +1,106 @@
 import {
-	SerializedType,
+	getSerializedBlobType,
 	getSerializedRefType,
 	SERIALIZED_STRING_TYPE,
-	getSerializedBlobType,
+	SerializedType,
 } from '../../common/data/serialized-type';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { serializeSchemaObject } from './schema-object';
 import { Either } from 'fp-ts/lib/Either';
 import { fromString, Ref } from '../../../../utils/ref';
-import { either, option, array, nonEmptyArray } from 'fp-ts';
+import { array, either, nonEmptyArray, option } from 'fp-ts';
 import { ResponseObject } from '../../../../schema/3.0/response-object';
 import { Option } from 'fp-ts/lib/Option';
 import { ReferenceObject, ReferenceObjectCodec } from '../../../../schema/3.0/reference-object';
 import { getKeyMatchValue, getKeyMatchValues, getResponseTypeFromMediaType, XHRResponseType } from '../../common/utils';
 import { SchemaObject } from '../../../../schema/3.0/schema-object';
 import { sequenceEither } from '@devexperts/utils/dist/adt/either.utils';
+import { combineReader } from '@devexperts/utils/dist/adt/reader.utils';
 
 const requestMediaRegexp = /^(video|audio|image|application|text|\*)\/(\w+|\*)/;
 
 export type SerializedResponse = { mediaType: string; schema: SerializedType };
 
-export const serializeResponseObject = (
-	from: Ref,
-	responseObject: ResponseObject,
-): Option<Either<Error, SerializedType>> =>
-	pipe(
-		responseObject.content,
-		option.chain(content => getKeyMatchValue(content, requestMediaRegexp)),
-		option.chain(({ key: mediaType, value: { schema } }) =>
-			pipe(
-				schema,
-				option.map(schema => ({ mediaType, schema })),
-			),
-		),
-		option.map(({ mediaType, schema }) => {
-			const resType = getResponseTypeFromMediaType(mediaType);
-			return serializeResponseSchema(resType, schema, from);
-		}),
-	);
+const serializeResponseSchema = combineReader(
+	serializeSchemaObject,
+	serializeSchemaObject => (
+		responseType: XHRResponseType,
+		schema: ReferenceObject | SchemaObject,
+		from: Ref,
+	): Either<Error, SerializedType> => {
+		switch (responseType) {
+			case 'json':
+				return ReferenceObjectCodec.is(schema)
+					? pipe(fromString(schema.$ref), either.map(getSerializedRefType(from)))
+					: serializeSchemaObject(from)(schema);
+			case 'text':
+				return either.right(SERIALIZED_STRING_TYPE);
+			case 'blob':
+				return getSerializedBlobType(from);
+		}
+	},
+);
 
-export const serializeResponseObjectWithMediaType = (
-	from: Ref,
-	responseObject: ResponseObject,
-): Option<Either<Error, SerializedResponse[]>> =>
-	pipe(
-		responseObject.content,
-		option.chain(content => getKeyMatchValues(content, requestMediaRegexp)),
-		option.chain(arr =>
-			pipe(
-				arr,
-				array.map(({ key: mediaType, value: { schema } }) =>
-					pipe(
-						schema,
-						option.map(schema => ({ mediaType, schema })),
-					),
+export const serializeResponseObject = combineReader(
+	serializeSchemaObject,
+	serializeResponseSchema,
+	(serializeSchemaObject, serializeResponseSchema) => (
+		from: Ref,
+		responseObject: ResponseObject,
+	): Option<Either<Error, SerializedType>> =>
+		pipe(
+			responseObject.content,
+			option.chain(content => getKeyMatchValue(content, requestMediaRegexp)),
+			option.chain(({ key: mediaType, value: { schema } }) =>
+				pipe(
+					schema,
+					option.map(schema => ({ mediaType, schema })),
 				),
-				array.filterMap(a => a),
-				nonEmptyArray.fromArray,
 			),
+			option.map(({ mediaType, schema }) => {
+				const resType = getResponseTypeFromMediaType(mediaType);
+				return serializeResponseSchema(resType, schema, from);
+			}),
 		),
-		option.map(arr =>
-			pipe(
-				arr,
-				array.map(({ mediaType, schema }) => {
-					const resType = getResponseTypeFromMediaType(mediaType);
-					return pipe(
-						serializeResponseSchema(resType, schema, from),
-						either.map(schema => ({
-							mediaType,
-							schema,
-						})),
-					);
-				}),
-				sequenceEither,
-			),
-		),
-	);
+);
 
-const serializeResponseSchema = (
-	responseType: XHRResponseType,
-	schema: ReferenceObject | SchemaObject,
-	from: Ref,
-): Either<Error, SerializedType> => {
-	switch (responseType) {
-		case 'json':
-			return ReferenceObjectCodec.is(schema)
-				? pipe(fromString(schema.$ref), either.map(getSerializedRefType(from)))
-				: serializeSchemaObject(from)(schema);
-		case 'text':
-			return either.right(SERIALIZED_STRING_TYPE);
-		case 'blob':
-			return getSerializedBlobType(from);
-	}
-};
+export const serializeResponseObjectWithMediaType = combineReader(
+	serializeResponseSchema,
+	serializeResponseSchema => (
+		from: Ref,
+		responseObject: ResponseObject,
+	): Option<Either<Error, SerializedResponse[]>> =>
+		pipe(
+			responseObject.content,
+			option.chain(content => getKeyMatchValues(content, requestMediaRegexp)),
+			option.chain(arr =>
+				pipe(
+					arr,
+					array.map(({ key: mediaType, value: { schema } }) =>
+						pipe(
+							schema,
+							option.map(schema => ({ mediaType, schema })),
+						),
+					),
+					array.filterMap(a => a),
+					nonEmptyArray.fromArray,
+				),
+			),
+			option.map(arr =>
+				pipe(
+					arr,
+					array.map(({ mediaType, schema }) => {
+						const resType = getResponseTypeFromMediaType(mediaType);
+						return pipe(
+							serializeResponseSchema(resType, schema, from),
+							either.map(schema => ({
+								mediaType,
+								schema,
+							})),
+						);
+					}),
+					sequenceEither,
+				),
+			),
+		),
+);

--- a/src/language/typescript/3.0/serializers/schema-object.ts
+++ b/src/language/typescript/3.0/serializers/schema-object.ts
@@ -20,7 +20,7 @@ import {
 } from '../../common/data/serialized-type';
 import { Either, mapLeft, right } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { either, option } from 'fp-ts';
+import { either, option, reader } from 'fp-ts';
 import { serializeDictionary } from '../../../../utils/types';
 import { constFalse, identity } from 'fp-ts/lib/function';
 import { includes } from '../../../../utils/array';
@@ -36,6 +36,7 @@ import {
 import { ReferenceObject, ReferenceObjectCodec } from '../../../../schema/3.0/reference-object';
 import { traverseNEAEither } from '../../../../utils/either';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { asks } from 'fp-ts/lib/Reader';
 
 type AdditionalProperties = boolean | ReferenceObject | SchemaObject;
 type AllowedAdditionalProperties = true | ReferenceObject | SchemaObject;
@@ -43,147 +44,162 @@ const isAllowedAdditionalProperties = (
 	additionalProperties: AdditionalProperties,
 ): additionalProperties is AllowedAdditionalProperties => additionalProperties !== false;
 
-export const serializeSchemaObject = (
+export type SerializeSchemaObjectWithRecursion = (
 	from: Ref,
+	shouldTrackRecursion: boolean,
 	name?: string,
-): ((schemaObject: SchemaObject) => Either<Error, SerializedType>) =>
-	serializeSchemaObjectWithRecursion(from, true, name);
+) => (schemaObject: SchemaObject) => Either<Error, SerializedType>;
+export type SerializePrimitive = (from: Ref, schemaObject: PrimitiveSchemaObject) => Either<Error, SerializedType>;
 
-const serializeSchemaObjectWithRecursion = (from: Ref, shouldTrackRecursion: boolean, name?: string) => (
-	schemaObject: SchemaObject,
-): Either<Error, SerializedType> => {
-	const isNullable = pipe(schemaObject.nullable, option.exists(identity));
-	if (OneOfSchemaObjectCodec.is(schemaObject)) {
-		return pipe(
-			serializeChildren(from, schemaObject.oneOf),
-			either.map(getSerializedUnionType),
-			either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
-			either.map(getSerializedNullableType(isNullable)),
-		);
-	}
+export interface SerializeSchemaObjectWithRecursionContext {
+	serializePrimitive: SerializePrimitive;
+}
 
-	if (AllOfSchemaObjectCodec.is(schemaObject)) {
-		return pipe(
-			serializeChildren(from, schemaObject.allOf),
-			either.map(getSerializedIntersectionType),
-			either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
-			either.map(getSerializedNullableType(isNullable)),
-		);
-	}
-
-	if (EnumSchemaObjectCodec.is(schemaObject)) {
-		return pipe(getSerializedEnumType(schemaObject.enum), getSerializedNullableType(isNullable), right);
-	}
-
-	switch (schemaObject.type) {
-		case 'string':
-		case 'boolean':
-		case 'integer':
-		case 'number': {
-			return pipe(serializePrimitive(from, schemaObject), either.map(getSerializedNullableType(isNullable)));
-		}
-		case 'array': {
-			const { items } = schemaObject;
-			const serialized = ReferenceObjectCodec.is(items)
-				? pipe(
-						fromString(items.$ref),
-						mapLeft(() => new Error(`Unable to serialize SchemaObject array items ref "${items.$ref}"`)),
-						either.map(getSerializedRefType(from)),
-				  )
-				: pipe(items, serializeSchemaObjectWithRecursion(from, false, undefined));
-
+export const serializeSchemaObjectWithRecursion = asks<
+	SerializeSchemaObjectWithRecursionContext,
+	SerializeSchemaObjectWithRecursion
+>(({ serializePrimitive }) => {
+	const doSerialize: SerializeSchemaObjectWithRecursion = (from, shouldTrackRecursion, name?) => schemaObject => {
+		const isNullable = pipe(schemaObject.nullable, option.exists(identity));
+		if (OneOfSchemaObjectCodec.is(schemaObject)) {
 			return pipe(
-				serialized,
-				either.map(getSerializedArrayType(schemaObject.minItems, name)),
+				serializeChildren(from, schemaObject.oneOf),
+				either.map(getSerializedUnionType),
+				either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
 				either.map(getSerializedNullableType(isNullable)),
 			);
 		}
-		case 'object': {
-			const additionalProperties = pipe(
-				schemaObject.additionalProperties,
-				option.filter(isAllowedAdditionalProperties),
-				option.map(additionalProperties => {
-					if (ReferenceObjectCodec.is(additionalProperties)) {
-						return pipe(
-							additionalProperties.$ref,
-							fromString,
-							mapLeft(
-								() =>
-									new Error(
-										`Unable to serialize SchemaObject additionalProperties ref "${additionalProperties.$ref}"`,
-									),
-							),
-							either.map(getSerializedRefType(from)),
-						);
-					} else {
-						return additionalProperties !== true
-							? pipe(additionalProperties, serializeSchemaObjectWithRecursion(from, false, undefined))
-							: right(SERIALIZED_UNKNOWN_TYPE);
-					}
-				}),
-				option.map(either.map(getSerializedDictionaryType(name))),
-				option.map(either.map(getSerializedRecursiveType(from, shouldTrackRecursion))),
-			);
-			const properties = pipe(
-				schemaObject.properties,
-				option.map(properties =>
-					pipe(
-						serializeDictionary(properties, (name, property) => {
-							const isRequired = pipe(
-								schemaObject.required,
-								option.map(includes(name)),
-								option.getOrElse(constFalse),
-							);
 
-							if (ReferenceObjectCodec.is(property)) {
-								return pipe(
-									property.$ref,
-									fromString,
-									mapLeft(
-										() =>
-											new Error(
-												`Unable to serialize SchemaObject property "${name}" ref "${property.$ref}"`,
-											),
-									),
-									either.map(getSerializedRefType(from)),
-									either.map(getSerializedOptionPropertyType(name, isRequired)),
-								);
-							} else {
-								return pipe(
-									property,
-									serializeSchemaObjectWithRecursion(from, false, undefined),
-									either.map(getSerializedOptionPropertyType(name, isRequired)),
-								);
-							}
-						}),
-						sequenceEither,
-						either.map(s => intercalateSerializedTypes(serializedType(';', ',', [], []), s)),
-						either.map(getSerializedObjectType(name)),
-						either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
-					),
-				),
-			);
+		if (AllOfSchemaObjectCodec.is(schemaObject)) {
 			return pipe(
-				additionalProperties,
-				option.alt(() => properties),
-				option.map(either.map(getSerializedNullableType(isNullable))),
-				option.getOrElse(() => right(SERIALIZED_UNKNOWN_TYPE)),
+				serializeChildren(from, schemaObject.allOf),
+				either.map(getSerializedIntersectionType),
+				either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
+				either.map(getSerializedNullableType(isNullable)),
 			);
 		}
-	}
-};
 
-const serializeChildren = (
+		if (EnumSchemaObjectCodec.is(schemaObject)) {
+			return pipe(getSerializedEnumType(schemaObject.enum), getSerializedNullableType(isNullable), right);
+		}
+
+		switch (schemaObject.type) {
+			case 'string':
+			case 'boolean':
+			case 'integer':
+			case 'number': {
+				return pipe(serializePrimitive(from, schemaObject), either.map(getSerializedNullableType(isNullable)));
+			}
+			case 'array': {
+				const { items } = schemaObject;
+				const serialized = ReferenceObjectCodec.is(items)
+					? pipe(
+							fromString(items.$ref),
+							mapLeft(
+								() => new Error(`Unable to serialize SchemaObject array items ref "${items.$ref}"`),
+							),
+							either.map(getSerializedRefType(from)),
+					  )
+					: pipe(items, doSerialize(from, false, undefined));
+
+				return pipe(
+					serialized,
+					either.map(getSerializedArrayType(schemaObject.minItems, name)),
+					either.map(getSerializedNullableType(isNullable)),
+				);
+			}
+			case 'object': {
+				const additionalProperties = pipe(
+					schemaObject.additionalProperties,
+					option.filter(isAllowedAdditionalProperties),
+					option.map(additionalProperties => {
+						if (ReferenceObjectCodec.is(additionalProperties)) {
+							return pipe(
+								additionalProperties.$ref,
+								fromString,
+								mapLeft(
+									() =>
+										new Error(
+											`Unable to serialize SchemaObject additionalProperties ref "${additionalProperties.$ref}"`,
+										),
+								),
+								either.map(getSerializedRefType(from)),
+							);
+						} else {
+							return additionalProperties !== true
+								? pipe(additionalProperties, doSerialize(from, false, undefined))
+								: right(SERIALIZED_UNKNOWN_TYPE);
+						}
+					}),
+					option.map(either.map(getSerializedDictionaryType(name))),
+					option.map(either.map(getSerializedRecursiveType(from, shouldTrackRecursion))),
+				);
+				const properties = pipe(
+					schemaObject.properties,
+					option.map(properties =>
+						pipe(
+							serializeDictionary(properties, (name, property) => {
+								const isRequired = pipe(
+									schemaObject.required,
+									option.map(includes(name)),
+									option.getOrElse(constFalse),
+								);
+
+								if (ReferenceObjectCodec.is(property)) {
+									return pipe(
+										property.$ref,
+										fromString,
+										mapLeft(
+											() =>
+												new Error(
+													`Unable to serialize SchemaObject property "${name}" ref "${property.$ref}"`,
+												),
+										),
+										either.map(getSerializedRefType(from)),
+										either.map(getSerializedOptionPropertyType(name, isRequired)),
+									);
+								} else {
+									return pipe(
+										property,
+										doSerialize(from, false, undefined),
+										either.map(getSerializedOptionPropertyType(name, isRequired)),
+									);
+								}
+							}),
+							sequenceEither,
+							either.map(s => intercalateSerializedTypes(serializedType(';', ',', [], []), s)),
+							either.map(getSerializedObjectType(name)),
+							either.map(getSerializedRecursiveType(from, shouldTrackRecursion)),
+						),
+					),
+				);
+				return pipe(
+					additionalProperties,
+					option.alt(() => properties),
+					option.map(either.map(getSerializedNullableType(isNullable))),
+					option.getOrElse(() => right(SERIALIZED_UNKNOWN_TYPE)),
+				);
+			}
+		}
+	};
+
+	const serializeChildren = (
+		from: Ref,
+		children: NonEmptyArray<ReferenceObject | SchemaObject>,
+	): Either<Error, NonEmptyArray<SerializedType>> =>
+		traverseNEAEither(children, item =>
+			ReferenceObjectCodec.is(item)
+				? pipe(fromString(item.$ref), either.map(getSerializedRefType(from)))
+				: doSerialize(from, false)(item),
+		);
+
+	return doSerialize;
+});
+
+export const serializePrimitiveDefault = (
 	from: Ref,
-	children: NonEmptyArray<ReferenceObject | SchemaObject>,
-): Either<Error, NonEmptyArray<SerializedType>> =>
-	traverseNEAEither(children, item =>
-		ReferenceObjectCodec.is(item)
-			? pipe(fromString(item.$ref), either.map(getSerializedRefType(from)))
-			: serializeSchemaObjectWithRecursion(from, false)(item),
-	);
-
-const serializePrimitive = (from: Ref, schemaObject: PrimitiveSchemaObject): Either<Error, SerializedType> => {
+	schemaObject: PrimitiveSchemaObject,
+): Either<Error, SerializedType> => {
 	switch (schemaObject.type) {
 		case 'string': {
 			return getSerializedStringType(from, schemaObject.format);
@@ -199,3 +215,18 @@ const serializePrimitive = (from: Ref, schemaObject: PrimitiveSchemaObject): Eit
 		}
 	}
 };
+
+export const serializeSchemaObject = pipe(
+	serializeSchemaObjectWithRecursion,
+	reader.map(
+		(serializeSchemaObjectWithRecursion: SerializeSchemaObjectWithRecursion) => (
+			from: Ref,
+			name?: string,
+		): ((schemaObject: SchemaObject) => Either<Error, SerializedType>) =>
+			serializeSchemaObjectWithRecursion(from, true, name),
+	),
+);
+
+export const serializeSchemaObjectDefault = serializeSchemaObject({
+	serializePrimitive: serializePrimitiveDefault,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,14 +661,14 @@ ansi-regex@^2.0.0:
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
 ansi-regex@^4.0.0, ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.0:
   version "5.0.1"
@@ -3389,10 +3389,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3424,13 +3424,13 @@ jsonparse@^1.2.0:
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
-    json-schema "0.2.3"
+    json-schema "0.4.0"
     verror "1.10.0"
 
 keyv@^3.0.0:
@@ -5340,9 +5340,9 @@ trim-newlines@^3.0.0:
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 ts-jest@^24.1.0:
-  version "24.1.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.1.0.tgz#2eaa813271a2987b7e6c3fefbda196301c131734"
-  integrity sha512-HEGfrIEAZKfu1pkaxB9au17b1d9b56YZSqz5eCVE8mX68+5reOvlM93xGOzzCREIov9mdH7JBG+s0UyNAqr0tQ==
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.3.0.tgz#b97814e3eab359ea840a1ac112deae68aa440869"
+  integrity sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"


### PR DESCRIPTION
This PR adds the ability to customize codecs for some primitive types. For example, this change was requested for this use-case: using Decimal.js instead of regular numbers to support arbitrary precision in requests and responses